### PR TITLE
Add IAA Order model

### DIFF
--- a/app/controllers/admin/iaa_orders_controller.rb
+++ b/app/controllers/admin/iaa_orders_controller.rb
@@ -1,0 +1,58 @@
+module Admin
+  class IAAOrdersController < Admin::ApplicationController
+    # Overwrite any of the RESTful controller actions to implement custom behavior
+    # For example, you may want to send an email after a foo is updated.
+    #
+    # def update
+    #   super
+    #   send_foo_updated_email(requested_resource)
+    # end
+
+    # Override this method to specify custom lookup behavior.
+    # This will be used to set the resource for the `show`, `edit`, and `update`
+    # actions.
+    #
+    # def find_resource(param)
+    #   Foo.find_by!(slug: param)
+    # end
+
+    # The result of this lookup will be available as `requested_resource`
+
+    # Override this if you have certain roles that require a subset
+    # this will be used to set the records shown on the `index` action.
+    #
+    # def scoped_resource
+    #   if current_user.super_admin?
+    #     resource_class
+    #   else
+    #     resource_class.with_less_stuff
+    #   end
+    # end
+
+    # Override `resource_params` if you want to transform the submitted
+    # data before it's persisted. For example, the following would turn all
+    # empty values into nil values. It uses other APIs such as `resource_class`
+    # and `dashboard`:
+    #
+    # def resource_params
+    #   params.require(resource_class.model_name.param_key).
+    #     permit(dashboard.permitted_attributes).
+    #     transform_values { |value| value == "" ? nil : value }
+    # end
+
+    # See https://administrate-prototype.herokuapp.com/customizing_controller_actions
+    # for more information
+
+    private
+
+    # Need to override the resource name since both parts of the name are
+    # acronyms and Administrate turns them into "IAAOrder".
+    # See https://github.com/thoughtbot/administrate/issues/1819
+    def translate_with_resource(key)
+      t(
+        "administrate.controller.#{key}",
+        resource: 'IAA Order',
+      )
+    end
+  end
+end

--- a/app/dashboards/account_dashboard.rb
+++ b/app/dashboards/account_dashboard.rb
@@ -15,7 +15,8 @@ class AccountDashboard < Administrate::BaseDashboard
     lg_agency_id: Field::Number,
     created_at: Field::DateTime,
     updated_at: Field::DateTime,
-    iaa_gtcs: Field::HasMany
+    iaa_gtcs: Field::HasMany,
+    iaa_orders: Field::HasMany
   }.freeze
 
   # COLLECTION_ATTRIBUTES
@@ -35,6 +36,7 @@ class AccountDashboard < Administrate::BaseDashboard
   name
   description
   iaa_gtcs
+  iaa_orders
   lg_agency_id
   created_at
   updated_at

--- a/app/dashboards/iaa_order_dashboard.rb
+++ b/app/dashboards/iaa_order_dashboard.rb
@@ -1,6 +1,6 @@
 require "administrate/base_dashboard"
 
-class IAAGTCDashboard < Administrate::BaseDashboard
+class IAAOrderDashboard < Administrate::BaseDashboard
   # ATTRIBUTE_TYPES
   # a hash that describes the type of each of the model's fields.
   #
@@ -8,19 +8,18 @@ class IAAGTCDashboard < Administrate::BaseDashboard
   # which determines how the attribute is displayed
   # on pages throughout the dashboard.
   ATTRIBUTE_TYPES = {
-    account: Field::BelongsTo,
-    iaa_orders: Field::HasMany,
+    iaa_gtc: Field::BelongsTo,
     id: Field::Number,
-    gtc_number: Field::String,
+    order_number: Field::Number,
     mod_number: Field::Number,
     name: Field::String,
     start_date: Field::Date,
     end_date: Field::Date,
     signed_date: Field::Date,
     estimated_amount: Field::Number,
-    active: Field::Boolean,
+    billed_amount: Field::Number,
     created_at: Field::DateTime,
-    updated_at: Field::DateTime
+    updated_at: Field::DateTime,
   }.freeze
 
   # COLLECTION_ATTRIBUTES
@@ -30,37 +29,38 @@ class IAAGTCDashboard < Administrate::BaseDashboard
   # Feel free to add, remove, or rearrange items.
   COLLECTION_ATTRIBUTES = %i[
   name
-  start_date
   end_date
-  account
+  billed_amount
+  estimated_amount
   ].freeze
 
   # SHOW_PAGE_ATTRIBUTES
   # an array of attributes that will be displayed on the model's show page.
   SHOW_PAGE_ATTRIBUTES = %i[
-  account
-  gtc_number
+  iaa_gtc
+  order_number
   mod_number
   start_date
   end_date
   signed_date
   estimated_amount
+  billed_amount
   created_at
   updated_at
-  iaa_orders
   ].freeze
 
   # FORM_ATTRIBUTES
   # an array of attributes that will be displayed
   # on the model's form (`new` and `edit`) pages.
   FORM_ATTRIBUTES = %i[
-  account
-  gtc_number
+  iaa_gtc
+  order_number
   mod_number
   start_date
   end_date
   signed_date
   estimated_amount
+  billed_amount
   ].freeze
 
   # COLLECTION_FILTERS
@@ -75,10 +75,10 @@ class IAAGTCDashboard < Administrate::BaseDashboard
   #   }.freeze
   COLLECTION_FILTERS = {}.freeze
 
-  # Overwrite this method to customize how iaas are displayed
+  # Overwrite this method to customize how iaa orders are displayed
   # across all pages of the admin dashboard.
-  #
-  def display_resource(iaa_gtc)
-    "#{iaa_gtc.name}"
+
+  def display_resource(iaa_order)
+    "#{iaa_order.name}"
   end
 end

--- a/app/models/account.rb
+++ b/app/models/account.rb
@@ -1,5 +1,6 @@
 class Account < ApplicationRecord
   has_many :iaa_gtcs
+  has_many :iaa_orders, through: :iaa_gtcs
   has_many :users
   has_many :apps
   validates :lg_account_id, presence: true,

--- a/app/models/iaa_gtc.rb
+++ b/app/models/iaa_gtc.rb
@@ -1,6 +1,8 @@
 class IAAGTC < ApplicationRecord
   belongs_to :account, dependent: :destroy
 
+  has_many :iaa_orders
+
   validates :gtc_number, presence: true,
                          uniqueness: { case_sensitive: false }
   validates :mod_number, presence: true,

--- a/app/models/iaa_order.rb
+++ b/app/models/iaa_order.rb
@@ -1,0 +1,30 @@
+class IAAOrder < ApplicationRecord
+  belongs_to :iaa_gtc, dependent: :destroy
+
+  validates :order_number, presence: true,
+                           numericality: { greater_than: 0 },
+                           uniqueness: { scope: :iaa_gtc }
+  validates :mod_number, presence: true,
+                         numericality: { greater_than_or_equal_to: 0 }
+  validates :estimated_amount, numericality: { greater_than_or_equal_to: 0,
+                                               allow_nil: true }
+  validates :billed_amount, numericality: { greater_than_or_equal_to: 0,
+                                            allow_nil: true }
+
+  delegate :gtc_number, to: :iaa_gtc
+
+  # Generate the "official" name for the 7600B form, comprised of the GTC
+  # number, the order number , and the mod number, both padded to 4 digits and
+  # all separated by dashes.
+  #
+  # @return [String] the official 7600B name
+  def name
+    "#{gtc_number}-#{name_str(order_number)}-#{name_str(mod_number)}"
+  end
+
+  private
+
+  def name_str(val)
+    val.to_s.rjust(4, '0')
+  end
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -2,6 +2,7 @@ Rails.application.routes.draw do
   namespace :admin do
       resources :accounts
       resources :iaa_gtcs
+      resources :iaa_orders
       resources :users
 
       root to: "users#index"

--- a/db/migrate/20201103210214_create_iaa_orders.rb
+++ b/db/migrate/20201103210214_create_iaa_orders.rb
@@ -1,0 +1,45 @@
+class CreateIAAOrders < ActiveRecord::Migration[6.0]
+  def change
+    create_table :iaa_orders do |t|
+      t.integer :order_number, null: false
+      t.integer :mod_number, null: false, default: 0
+      t.date :start_date
+      t.date :end_date
+      t.date :signed_date
+      t.integer :estimated_amount
+      t.integer :billed_amount
+
+      t.references :iaa_gtc, foreign_key: true, null: false
+
+      t.timestamps
+    end
+
+    add_index :iaa_orders, [:iaa_gtc_id, :order_number], unique: true
+
+    reversible do |dir|
+      dir.up do
+        change_table :accounts do |t|
+          t.remove :iaa_7600b
+          t.remove :iaa_7600b_start
+          t.remove :iaa_7600b_end
+          t.remove :iaa_7600b_amount
+          t.remove :iaa_7600b_billed
+          t.remove :ial1_users_in_pop
+          t.remove :ial2_users_in_pop
+        end
+      end
+
+      dir.down do
+        change_table :accounts do |t|
+          t.string :iaa_7600b
+          t.date :iaa_7600b_start
+          t.date :iaa_7600b_end
+          t.integer :iaa_7600b_amount
+          t.integer :iaa_7600b_billed
+          t.integer :ial1_users_in_pop
+          t.integer :ial2_users_in_pop
+        end
+      end
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_11_03_203609) do
+ActiveRecord::Schema.define(version: 2020_11_03_210214) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -20,14 +20,7 @@ ActiveRecord::Schema.define(version: 2020_11_03_203609) do
     t.string "name", null: false
     t.text "description"
     t.integer "lg_agency_id"
-    t.string "iaa_7600b"
-    t.date "iaa_7600b_start"
-    t.date "iaa_7600b_end"
-    t.integer "iaa_7600b_amount"
-    t.integer "iaa_7600b_billed"
     t.integer "pricing"
-    t.integer "ial1_users_in_pop"
-    t.integer "ial2_users_in_pop"
     t.date "became_partner"
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
@@ -75,6 +68,21 @@ ActiveRecord::Schema.define(version: 2020_11_03_203609) do
     t.index ["gtc_number"], name: "index_iaa_gtcs_on_gtc_number", unique: true
   end
 
+  create_table "iaa_orders", force: :cascade do |t|
+    t.integer "order_number", null: false
+    t.integer "mod_number", default: 0, null: false
+    t.date "start_date"
+    t.date "end_date"
+    t.date "signed_date"
+    t.integer "estimated_amount"
+    t.integer "billed_amount"
+    t.bigint "iaa_gtc_id", null: false
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+    t.index ["iaa_gtc_id", "order_number"], name: "index_iaa_orders_on_iaa_gtc_id_and_order_number", unique: true
+    t.index ["iaa_gtc_id"], name: "index_iaa_orders_on_iaa_gtc_id"
+  end
+
   create_table "users", force: :cascade do |t|
     t.bigint "account_id"
     t.string "uuid"
@@ -97,4 +105,5 @@ ActiveRecord::Schema.define(version: 2020_11_03_203609) do
   end
 
   add_foreign_key "iaa_gtcs", "accounts"
+  add_foreign_key "iaa_orders", "iaa_gtcs"
 end

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -11,7 +11,7 @@
 # end
 
 if Rails.env.development? || Rails.env.test?
-  User.find_or_create_by email: 'admin@gsa.gov' do |user|
+  User.find_or_create_by email: 'test1@test.com' do |user|
     user.admin = true
     user.lg_account_id = 'LG-E-DOT'
   end
@@ -72,11 +72,6 @@ Account.create(
   lg_account_id: 'LG-E-DOT',
   name: 'DOT / CISO',
   lg_agency_id: 1,
-  iaa_7600b: '0002',
-  iaa_7600b_start: Date.new(2020, 3, 12),
-  iaa_7600b_end: Date.new(2021, 3, 11),
-  iaa_7600b_amount: 124_000,
-  iaa_7600b_billed: 47_000,
   pricing: 2,
   became_partner: Date.new(2019, 3, 12),
   users: [u1, u2, u3],

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -9,6 +9,11 @@ FactoryBot.define do
     gtc_number { "LG#{Faker::Name.initials(number: 3)}FY210001" }
   end
 
+  factory :iaa_order do
+    iaa_gtc
+    sequence(:order_number) { |i| i }
+  end
+
   factory :user do
     email { Faker::Internet.email }
   end

--- a/spec/features/administrate/iaa_gtc_dashboard_spec.rb
+++ b/spec/features/administrate/iaa_gtc_dashboard_spec.rb
@@ -34,7 +34,7 @@ RSpec.describe 'IAA GTC dashboard', type: :feature do
 
       it 'works' do
         visit admin_iaa_gtc_path(iaa_gtc)
-        click_on "Edit #{iaa_gtc.gtc_number}"
+        click_on "Edit #{iaa_gtc.name}"
         fill_in 'GTC number', with: new_number
         click_on 'Update IAA GTC'
         expect(page).to have_content('IAA GTC was successfully updated.')

--- a/spec/features/administrate/iaa_order_dashboard_spec.rb
+++ b/spec/features/administrate/iaa_order_dashboard_spec.rb
@@ -1,0 +1,57 @@
+require 'rails_helper'
+
+RSpec.describe 'IAA Order dashboard', type: :feature do
+  context 'as an admin' do
+    let(:admin) { create(:user, admin: true) }
+
+    before { sign_in_with_warden(admin) }
+
+    describe 'index' do
+      it 'works' do
+        visit admin_iaa_orders_path
+        expect(page).to have_content('Back to app')
+      end
+    end
+
+    describe 'create' do
+      let!(:gtc) { create(:iaa_gtc) }
+
+      it 'works' do
+        visit admin_iaa_orders_path
+        click_on 'New IAA Order'
+        select gtc.name, from: 'IAA GTC'
+        fill_in 'Order number', with: 1
+        click_on 'Create IAA order'
+        expect(page).to have_content('IAA Order was successfully created.')
+        # implictly tests the show view since that's where it redirects
+      end
+    end
+
+    describe 'update' do
+      let(:old_number) { 1 }
+      let(:new_number) { 2 }
+      let(:iaa_order) { create(:iaa_order, order_number: old_number) }
+
+      it 'works' do
+        visit admin_iaa_order_path(iaa_order)
+        click_on "Edit #{iaa_order.name}"
+        fill_in 'Order number', with: new_number
+        click_on 'Update IAA order'
+        expect(page).to have_content('IAA Order was successfully updated.')
+      end
+    end
+
+    describe 'destroy' do
+      let!(:iaa_order) { create(:iaa_order) }
+
+      it 'works' do
+        visit admin_iaa_orders_path
+        within "tr[data-url=\"#{admin_iaa_order_path(iaa_order)}\"]" do
+          click_on 'Destroy'
+        end
+        expect(page).to have_content('IAA Order was successfully destroyed.')
+      end
+    end
+  end
+end
+

--- a/spec/models/account_spec.rb
+++ b/spec/models/account_spec.rb
@@ -13,5 +13,6 @@ RSpec.describe Account, type: :model do
     subject { build(:account) }
 
     it { is_expected.to have_many(:iaa_gtcs) }
+    it { is_expected.to have_many(:iaa_orders).through(:iaa_gtcs) }
   end
 end

--- a/spec/models/iaa_gtc_spec.rb
+++ b/spec/models/iaa_gtc_spec.rb
@@ -15,6 +15,7 @@ RSpec.describe IAAGTC, type: :model do
     subject { build(:iaa_gtc) }
 
     it { is_expected.to belong_to(:account).dependent(:destroy) }
+    it { is_expected.to have_many(:iaa_orders) }
   end
 
   describe '#name' do

--- a/spec/models/iaa_order_spec.rb
+++ b/spec/models/iaa_order_spec.rb
@@ -1,0 +1,36 @@
+require 'rails_helper'
+
+RSpec.describe IAAOrder, type: :model do
+  describe 'validations' do
+    subject { build(:iaa_order) }
+
+    it { is_expected.to validate_presence_of(:order_number) }
+    it { is_expected.to validate_numericality_of(:order_number).is_greater_than(0) }
+
+    describe 'order_number' do
+      it 'must be unique scoped to IAA' do
+        order = create(:iaa_order, order_number: 1)
+        other_order = build(:iaa_order, iaa_gtc: order.iaa_gtc, order_number: 1)
+        expect(other_order).not_to be_valid
+      end
+    end
+
+    it { is_expected.to validate_presence_of(:mod_number) }
+    it { is_expected.to validate_numericality_of(:mod_number).is_greater_than_or_equal_to(0) }
+    it { is_expected.to validate_numericality_of(:estimated_amount).is_greater_than_or_equal_to(0).allow_nil }
+    it { is_expected.to validate_numericality_of(:billed_amount).is_greater_than_or_equal_to(0).allow_nil }
+  end
+
+  describe 'associations' do
+    it { is_expected.to belong_to(:iaa_gtc).dependent(:destroy) }
+  end
+
+  describe '#name' do
+    it 'generates the appropriate IAA Order string' do
+      gtc = build(:iaa_gtc, gtc_number: 'FOOBAR')
+      order = build(:iaa_order, iaa_gtc: gtc, order_number: 1, mod_number: 2)
+
+      expect(order.name).to eq('FOOBAR-0001-0002')
+    end
+  end
+end


### PR DESCRIPTION
Add IAAOrder to represent 7600B forms, belonging to an IAAGTC. Removes
unneeded fields from the accounts table and updates existing dashboards
as needed.

Blocked on #6 