### PR TITLE
Replace App model with Integration model

### DIFF
--- a/app/controllers/admin/integrations_controller.rb
+++ b/app/controllers/admin/integrations_controller.rb
@@ -1,0 +1,46 @@
+module Admin
+  class IntegrationsController < Admin::ApplicationController
+    # Overwrite any of the RESTful controller actions to implement custom behavior
+    # For example, you may want to send an email after a foo is updated.
+    #
+    # def update
+    #   super
+    #   send_foo_updated_email(requested_resource)
+    # end
+
+    # Override this method to specify custom lookup behavior.
+    # This will be used to set the resource for the `show`, `edit`, and `update`
+    # actions.
+    #
+    # def find_resource(param)
+    #   Foo.find_by!(slug: param)
+    # end
+
+    # The result of this lookup will be available as `requested_resource`
+
+    # Override this if you have certain roles that require a subset
+    # this will be used to set the records shown on the `index` action.
+    #
+    # def scoped_resource
+    #   if current_user.super_admin?
+    #     resource_class
+    #   else
+    #     resource_class.with_less_stuff
+    #   end
+    # end
+
+    # Override `resource_params` if you want to transform the submitted
+    # data before it's persisted. For example, the following would turn all
+    # empty values into nil values. It uses other APIs such as `resource_class`
+    # and `dashboard`:
+    #
+    # def resource_params
+    #   params.require(resource_class.model_name.param_key).
+    #     permit(dashboard.permitted_attributes).
+    #     transform_values { |value| value == "" ? nil : value }
+    # end
+
+    # See https://administrate-prototype.herokuapp.com/customizing_controller_actions
+    # for more information
+  end
+end

--- a/app/dashboards/integration_dashboard.rb
+++ b/app/dashboards/integration_dashboard.rb
@@ -1,6 +1,6 @@
 require "administrate/base_dashboard"
 
-class AccountDashboard < Administrate::BaseDashboard
+class IntegrationDashboard < Administrate::BaseDashboard
   # ATTRIBUTE_TYPES
   # a hash that describes the type of each of the model's fields.
   #
@@ -8,16 +8,22 @@ class AccountDashboard < Administrate::BaseDashboard
   # which determines how the attribute is displayed
   # on pages throughout the dashboard.
   ATTRIBUTE_TYPES = {
+    account: Field::BelongsTo,
     id: Field::Number,
-    lg_account_id: Field::String,
+    issuer: Field::String,
     name: Field::String,
     description: Field::Text,
-    lg_agency_id: Field::Number,
+    dashboard_url: Field::String,
+    ial2: Field::Boolean,
+    protocol: Field::Select.with_options(
+      searchable: false,
+      collection: ->(field) { field.resource.class.send(field.attribute.to_s.pluralize).keys }
+    ),
+    url: Field::String,
+    go_live: Field::Date,
+    prod_deploy: Field::Date,
     created_at: Field::DateTime,
     updated_at: Field::DateTime,
-    iaa_gtcs: Field::HasMany,
-    iaa_orders: Field::HasMany,
-    integrations: Field::HasMany
   }.freeze
 
   # COLLECTION_ATTRIBUTES
@@ -26,20 +32,25 @@ class AccountDashboard < Administrate::BaseDashboard
   # By default, it's limited to four items to reduce clutter on index pages.
   # Feel free to add, remove, or rearrange items.
   COLLECTION_ATTRIBUTES = %i[
-  lg_account_id
   name
+  protocol
+  account
+  issuer
   ].freeze
 
   # SHOW_PAGE_ATTRIBUTES
   # an array of attributes that will be displayed on the model's show page.
   SHOW_PAGE_ATTRIBUTES = %i[
-  lg_account_id
+  account
+  issuer
   name
   description
-  iaa_gtcs
-  iaa_orders
-  integrations
-  lg_agency_id
+  dashboard_url
+  ial2
+  protocol
+  url
+  go_live
+  prod_deploy
   created_at
   updated_at
   ].freeze
@@ -48,10 +59,16 @@ class AccountDashboard < Administrate::BaseDashboard
   # an array of attributes that will be displayed
   # on the model's form (`new` and `edit`) pages.
   FORM_ATTRIBUTES = %i[
-  lg_account_id
+  account
+  issuer
   name
   description
-  lg_agency_id
+  dashboard_url
+  ial2
+  protocol
+  url
+  go_live
+  prod_deploy
   ].freeze
 
   # COLLECTION_FILTERS
@@ -66,10 +83,10 @@ class AccountDashboard < Administrate::BaseDashboard
   #   }.freeze
   COLLECTION_FILTERS = {}.freeze
 
-  # Overwrite this method to customize how accounts are displayed
+  # Overwrite this method to customize how integrations are displayed
   # across all pages of the admin dashboard.
-  #
-  def display_resource(account)
-    "#{account.name}"
+
+  def display_resource(integration)
+    "#{integration.name}"
   end
 end

--- a/app/models/account.rb
+++ b/app/models/account.rb
@@ -1,8 +1,9 @@
 class Account < ApplicationRecord
   has_many :iaa_gtcs
   has_many :iaa_orders, through: :iaa_gtcs
+  has_many :integrations
   has_many :users
-  has_many :apps
+
   validates :lg_account_id, presence: true,
                             uniqueness: { case_sensitive: false }
   validates :name, presence: true

--- a/app/models/integration.rb
+++ b/app/models/integration.rb
@@ -1,0 +1,10 @@
+class Integration < ApplicationRecord
+  belongs_to :account, dependent: :destroy
+
+  validates :issuer, presence: true,
+                     uniqueness: { case_sensitive: false }
+  validates :name, presence: true
+  validates :protocol, presence: true
+
+  enum protocol: { oidc: 'oidc', saml: 'saml' }
+end

--- a/config/initializers/inflections.rb
+++ b/config/initializers/inflections.rb
@@ -2,6 +2,7 @@ ActiveSupport::Inflector.inflections(:en) do |inflect|
   inflect.acronym('GTC')
   inflect.acronym('GTCs')
   inflect.acronym('IAA')
-  inflect.acronym('IAAs')
+  inflect.acronym('IAL2')
+  inflect.acronym('URL')
 end
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -3,6 +3,7 @@ Rails.application.routes.draw do
       resources :accounts
       resources :iaa_gtcs
       resources :iaa_orders
+      resources :integrations
       resources :users
 
       root to: "users#index"

--- a/db/migrate/20201104021414_create_integrations.rb
+++ b/db/migrate/20201104021414_create_integrations.rb
@@ -1,0 +1,51 @@
+class CreateIntegrations < ActiveRecord::Migration[6.0]
+  def change
+    create_table :integrations do |t|
+      t.string :issuer, null: false
+      t.string :name, null: false
+      t.text :description
+      t.string :dashboard_url
+      t.boolean :ial2, null: false, default: false
+      t.string :protocol, null: false, default: 'oidc'
+      t.string :url
+      t.date :go_live
+      t.date :prod_deploy
+
+      t.references :account, foreign_key: true
+
+      t.timestamps
+
+      t.index :issuer, unique: true
+    end
+
+    reversible do |dir|
+      dir.up do
+        drop_table :apps
+      end
+
+      dir.down do
+        create_table :apps do |t|
+          t.belongs_to :account
+          t.string   :lg_app_id, null: false
+          t.string   :name, null: false
+          t.text     :description
+          t.integer  :ial, null: false
+          t.text     :lg_client_ids, array: true, default: []
+          t.string   :identity_protocol
+          t.date     :certificate_expiration
+          t.boolean  :approved, default: false, null: false
+          t.boolean  :live, default: false, null: false
+          t.date     :live_on
+          t.string   :url
+          t.integer  :users_in_pop
+          t.integer  :users_lifetime
+          t.integer  :auths_in_pop
+          t.integer  :auths_lifetime
+          t.integer  :ial2_users_in_pop
+          t.integer  :ial2_users_lifetime
+          t.timestamps
+        end
+      end
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_11_03_210214) do
+ActiveRecord::Schema.define(version: 2020_11_04_021414) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -28,30 +28,6 @@ ActiveRecord::Schema.define(version: 2020_11_03_210214) do
 
   create_table "agencies", force: :cascade do |t|
     t.string "name", null: false
-  end
-
-  create_table "apps", force: :cascade do |t|
-    t.bigint "account_id"
-    t.string "lg_app_id", null: false
-    t.string "name", null: false
-    t.text "description"
-    t.integer "ial", null: false
-    t.text "lg_client_ids", default: [], array: true
-    t.string "identity_protocol"
-    t.date "certificate_expiration"
-    t.boolean "approved", default: false, null: false
-    t.boolean "live", default: false, null: false
-    t.date "live_on"
-    t.string "url"
-    t.integer "users_in_pop"
-    t.integer "users_lifetime"
-    t.integer "auths_in_pop"
-    t.integer "auths_lifetime"
-    t.integer "ial2_users_in_pop"
-    t.integer "ial2_users_lifetime"
-    t.datetime "created_at", precision: 6, null: false
-    t.datetime "updated_at", precision: 6, null: false
-    t.index ["account_id"], name: "index_apps_on_account_id"
   end
 
   create_table "iaa_gtcs", force: :cascade do |t|
@@ -83,6 +59,23 @@ ActiveRecord::Schema.define(version: 2020_11_03_210214) do
     t.index ["iaa_gtc_id"], name: "index_iaa_orders_on_iaa_gtc_id"
   end
 
+  create_table "integrations", force: :cascade do |t|
+    t.string "issuer", null: false
+    t.string "name", null: false
+    t.text "description"
+    t.string "dashboard_url"
+    t.boolean "ial2", default: false, null: false
+    t.string "protocol", default: "oidc", null: false
+    t.string "url"
+    t.date "go_live"
+    t.date "prod_deploy"
+    t.bigint "account_id"
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+    t.index ["account_id"], name: "index_integrations_on_account_id"
+    t.index ["issuer"], name: "index_integrations_on_issuer", unique: true
+  end
+
   create_table "users", force: :cascade do |t|
     t.bigint "account_id"
     t.string "uuid"
@@ -106,4 +99,5 @@ ActiveRecord::Schema.define(version: 2020_11_03_210214) do
 
   add_foreign_key "iaa_gtcs", "accounts"
   add_foreign_key "iaa_orders", "iaa_gtcs"
+  add_foreign_key "integrations", "accounts"
 end

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -44,29 +44,29 @@ u3 = User.create(
   lg_account_id: 'LG-E-DOT'
 )
 
-a1 = App.create(
-  lg_app_id: '78937628',
-  name: 'FMCSA Drug & Alcohol Clearinghouse',
-  description: 'The Clearinghouse is a secure online database that gives employers, the Federal Motor Carrier Safety Administration (FMCSA), State Driver Licensing Agencies (SDLAs), and State law enforcement personnel real-time information about commercial driver’s license (CDL) and commercial learner’s permit (CLP) holders’ drug and alcohol program violations.',
-  ial: 1,
-  lg_client_ids: ['9823745892375.login.gov'],
-  identity_protocol: 'oidc',
-  approved: true,
-  live: true,
-  live_on: Date.new(2019, 4, 27),
-  url: 'https://clearinghouse.fmcsa.dot.gov',
-  users_in_pop: 54_902,
-  users_lifetime: 763_187,
-  auths_in_pop: 219_608,
-  auths_lifetime: 3_052_748
-)
-
-a2 = App.create(
-  lg_app_id: '907647823',
-  name: 'Robo Car Registry',
-  description: '',
-  ial: 2
-)
+# a1 = App.create(
+#   lg_app_id: '78937628',
+#   name: 'FMCSA Drug & Alcohol Clearinghouse',
+#   description: 'The Clearinghouse is a secure online database that gives employers, the Federal Motor Carrier Safety Administration (FMCSA), State Driver Licensing Agencies (SDLAs), and State law enforcement personnel real-time information about commercial driver’s license (CDL) and commercial learner’s permit (CLP) holders’ drug and alcohol program violations.',
+#   ial: 1,
+#   lg_client_ids: ['9823745892375.login.gov'],
+#   identity_protocol: 'oidc',
+#   approved: true,
+#   live: true,
+#   live_on: Date.new(2019, 4, 27),
+#   url: 'https://clearinghouse.fmcsa.dot.gov',
+#   users_in_pop: 54_902,
+#   users_lifetime: 763_187,
+#   auths_in_pop: 219_608,
+#   auths_lifetime: 3_052_748
+# )
+#
+# a2 = App.create(
+#   lg_app_id: '907647823',
+#   name: 'Robo Car Registry',
+#   description: '',
+#   ial: 2
+# )
 
 Account.create(
   lg_account_id: 'LG-E-DOT',
@@ -75,7 +75,7 @@ Account.create(
   pricing: 2,
   became_partner: Date.new(2019, 3, 12),
   users: [u1, u2, u3],
-  apps: [a1, a2]
+  # apps: [a1, a2]
 )
 
 Account.create(lg_account_id: 'LG-E-DOL', name: 'DOL / OCIO')

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -14,6 +14,16 @@ FactoryBot.define do
     sequence(:order_number) { |i| i }
   end
 
+  factory :integration do
+    account
+    name { Faker::Internet.domain_word.titleize }
+    issuer do
+      agency = Faker::Name.initials(number: 3).downcase
+
+      "urn:gov:gsa:openidconnect.profiles:sp:sso:#{agency}:#{name.downcase}"
+    end
+  end
+
   factory :user do
     email { Faker::Internet.email }
   end

--- a/spec/features/integration_dashboard_spec.rb
+++ b/spec/features/integration_dashboard_spec.rb
@@ -1,0 +1,70 @@
+require 'rails_helper'
+
+RSpec.describe 'Integration dashboard', type: :feature do
+  context 'as an admin' do
+    let(:admin) { create(:user, admin: true) }
+
+    before { sign_in_with_warden(admin) }
+
+    describe 'index' do
+      it 'works' do
+        visit admin_integrations_path
+        expect(page).to have_content('Back to app')
+      end
+    end
+
+    describe 'create' do
+      let!(:account) { create(:account) }
+
+      it 'works' do
+        visit admin_integrations_path
+        click_on 'New Integration'
+        select account.name, from: 'Account'
+        fill_in 'Issuer', with: 'urn:gov:gsa:openidconnect.profiles:sp:sso:gsa:foo'
+        fill_in 'Name', with: 'Awesome App'
+        click_on 'Create Integration'
+        expect(page).to have_content('Integration was successfully created.')
+        # implictly tests the show view since that's where it redirects
+      end
+    end
+
+    describe 'update' do
+      let(:old_name) { 'Awesome App' }
+      let(:new_name) { 'Amazing App' }
+      let(:integration) { create(:integration, name: old_name) }
+
+      it 'works' do
+        visit admin_integration_path(integration)
+        click_on "Edit #{integration.name}"
+        fill_in 'Name', with: new_name
+        click_on 'Update Integration'
+        expect(page).to have_content('Integration was successfully updated.')
+      end
+    end
+
+    describe 'destroy' do
+      let!(:integration) { create(:integration) }
+
+      it 'works' do
+        visit admin_integrations_path
+        within "tr[data-url=\"#{admin_integration_path(integration)}\"]" do
+          click_on 'Destroy'
+        end
+        expect(page).to have_content('Integration was successfully destroyed.')
+      end
+    end
+  end
+
+  context 'as non-admin' do
+    let(:user) { create(:user, admin: false) }
+
+    before { sign_in_with_warden(user) }
+
+    describe 'dashboard' do
+      it 'is not permitted' do
+        visit admin_integrations_path
+        expect(page).to have_content('You are not permitted to view that page.')
+      end
+    end
+  end
+end

--- a/spec/models/account_spec.rb
+++ b/spec/models/account_spec.rb
@@ -14,5 +14,6 @@ RSpec.describe Account, type: :model do
 
     it { is_expected.to have_many(:iaa_gtcs) }
     it { is_expected.to have_many(:iaa_orders).through(:iaa_gtcs) }
+    it { is_expected.to have_many(:integrations) }
   end
 end

--- a/spec/models/integration_spec.rb
+++ b/spec/models/integration_spec.rb
@@ -1,0 +1,19 @@
+require 'rails_helper'
+
+RSpec.describe Integration, type: :model do
+  describe 'validations' do
+    subject { build(:integration) }
+
+    it { is_expected.to validate_presence_of(:issuer) }
+    it { is_expected.to validate_uniqueness_of(:issuer).case_insensitive }
+    it { is_expected.to validate_presence_of(:name) }
+    it { is_expected.to validate_presence_of(:protocol) }
+    it { is_expected.to define_enum_for(:protocol).with_values(oidc: 'oidc', saml: 'saml').backed_by_column_of_type(:string) }
+  end
+
+  describe 'associations' do
+    subject { build(:integration) }
+
+    it { is_expected.to belong_to(:account).dependent(:destroy) }
+  end
+end


### PR DESCRIPTION
Replace App model with Integration model and set up dashboard. This
includes:
- Enum field for protocol backed by a string column
- Boolean field for IAL2 (assume all integrations will be IAL1)
- Ignore estimates and usage tracking for now

Not sure this is done but wanted to get it ready. Ideally I'd like to figure out how to get the protocol acronyms displayed in all caps before we merge in but it's not strictly necessary.

Blocked on #7 