### PR TITLE
Fix datepicker / turbolinks

### DIFF
--- a/app/javascript/components/date_time_picker.js
+++ b/app/javascript/components/date_time_picker.js
@@ -19,7 +19,15 @@ function bindDateTimePickers() {
       altFormat: 'F J (D), Y - h:i:S K',
       dateFormat: 'Z' // Y-m-d H:i
     })
-  })
+  });
+
+  [...document.querySelectorAll('[data-type="date"]')].forEach((date) => {
+    flatpickr(date, {
+      altInput: true,
+      altFormat: "F j, Y",
+      dateFormat: "Y-m-d"
+    })
+  });
 }
 
 document.addEventListener("turbolinks:load", function () {

--- a/app/javascript/packs/administrate.js
+++ b/app/javascript/packs/administrate.js
@@ -4,7 +4,7 @@
 // that code so it'll be compiled.
 
 require("@rails/ujs").start()
-// require("turbolinks").start()
+require("turbolinks").start()
 
 // The next line you only need if you want ActiveStorage support
 require("@rails/activestorage").start()

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
     "@rails/webpacker": "5.2.1",
     "flatpickr": "^4.6.6",
     "trix": "^1.3.0",
+    "turbolinks": "^5.2.0",
     "uswds": "^2.8"
   },
   "version": "0.1.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -7304,6 +7304,11 @@ tunnel-agent@^0.6.0:
   dependencies:
     safe-buffer "^5.0.1"
 
+turbolinks@^5.2.0:
+  version "5.2.0"
+  resolved "https://registry.yarnpkg.com/turbolinks/-/turbolinks-5.2.0.tgz#e6877a55ea5c1cb3bb225f0a4ae303d6d32ff77c"
+  integrity sha512-pMiez3tyBo6uRHFNNZoYMmrES/IaGgMhQQM+VFF36keryjb5ms0XkVpmKHkfW/4Vy96qiGW3K9bz0tF5sK9bBw==
+
 tweetnacl@^0.14.3, tweetnacl@~0.14.0:
   version "0.14.5"
   resolved "https://registry.yarnpkg.com/tweetnacl/-/tweetnacl-0.14.5.tgz#5ae68177f192d4456269d108afa93ff8743f4f64"


### PR DESCRIPTION
We were missing turbolinks in package.json and the datepicker config was missing an option for date fields too.