### PR TITLE
Add status lookup tables for accounts, IAAs, and integrations

### DIFF
--- a/app/controllers/admin/account_statuses_controller.rb
+++ b/app/controllers/admin/account_statuses_controller.rb
@@ -1,5 +1,5 @@
 module Admin
-  class AccountContactsController < Admin::ApplicationController
+  class AccountStatusesController < Admin::ApplicationController
     # Overwrite any of the RESTful controller actions to implement custom behavior
     # For example, you may want to send an email after a foo is updated.
     #
@@ -52,7 +52,7 @@ module Admin
     def translate_with_resource(key)
       t(
         "administrate.controller.#{key}",
-        resource: 'Account Contact',
+        resource: 'Account Status',
       )
     end
   end

--- a/app/controllers/admin/iaa_statuses_controller.rb
+++ b/app/controllers/admin/iaa_statuses_controller.rb
@@ -1,5 +1,5 @@
 module Admin
-  class AccountContactsController < Admin::ApplicationController
+  class IAAStatusesController < Admin::ApplicationController
     # Overwrite any of the RESTful controller actions to implement custom behavior
     # For example, you may want to send an email after a foo is updated.
     #
@@ -52,7 +52,7 @@ module Admin
     def translate_with_resource(key)
       t(
         "administrate.controller.#{key}",
-        resource: 'Account Contact',
+        resource: 'IAA Status',
       )
     end
   end

--- a/app/controllers/admin/integration_contacts_controller.rb
+++ b/app/controllers/admin/integration_contacts_controller.rb
@@ -52,7 +52,7 @@ module Admin
     def translate_with_resource(key)
       t(
         "administrate.controller.#{key}",
-        resource: 'Integration contact',
+        resource: 'Integration Contact',
       )
     end
   end

--- a/app/controllers/admin/integration_statuses_controller.rb
+++ b/app/controllers/admin/integration_statuses_controller.rb
@@ -1,5 +1,5 @@
 module Admin
-  class AccountContactsController < Admin::ApplicationController
+  class IntegrationStatusesController < Admin::ApplicationController
     # Overwrite any of the RESTful controller actions to implement custom behavior
     # For example, you may want to send an email after a foo is updated.
     #
@@ -52,7 +52,7 @@ module Admin
     def translate_with_resource(key)
       t(
         "administrate.controller.#{key}",
-        resource: 'Account Contact',
+        resource: 'Integration Status',
       )
     end
   end

--- a/app/dashboards/account_dashboard.rb
+++ b/app/dashboards/account_dashboard.rb
@@ -12,6 +12,7 @@ class AccountDashboard < Administrate::BaseDashboard
     lg_account_id: Field::String,
     name: Field::String,
     description: Field::Text,
+    account_status: Field::BelongsTo,
     lg_agency_id: Field::Number,
     created_at: Field::DateTime,
     updated_at: Field::DateTime,
@@ -30,6 +31,7 @@ class AccountDashboard < Administrate::BaseDashboard
   COLLECTION_ATTRIBUTES = %i[
   lg_account_id
   name
+  account_status
   ].freeze
 
   # SHOW_PAGE_ATTRIBUTES
@@ -38,6 +40,7 @@ class AccountDashboard < Administrate::BaseDashboard
   lg_account_id
   name
   description
+  account_status
   iaa_gtcs
   iaa_orders
   integrations
@@ -54,6 +57,7 @@ class AccountDashboard < Administrate::BaseDashboard
   lg_account_id
   name
   description
+  account_status
   lg_agency_id
   ].freeze
 

--- a/app/dashboards/account_status_dashboard.rb
+++ b/app/dashboards/account_status_dashboard.rb
@@ -1,6 +1,6 @@
 require "administrate/base_dashboard"
 
-class IAAOrderDashboard < Administrate::BaseDashboard
+class AccountStatusDashboard < Administrate::BaseDashboard
   # ATTRIBUTE_TYPES
   # a hash that describes the type of each of the model's fields.
   #
@@ -8,17 +8,10 @@ class IAAOrderDashboard < Administrate::BaseDashboard
   # which determines how the attribute is displayed
   # on pages throughout the dashboard.
   ATTRIBUTE_TYPES = {
-    iaa_gtc: Field::BelongsTo,
+    accounts: Field::HasMany,
     id: Field::Number,
-    order_number: Field::Number,
-    mod_number: Field::Number,
     name: Field::String,
-    iaa_status: Field::BelongsTo,
-    start_date: Field::Date,
-    end_date: Field::Date,
-    signed_date: Field::Date,
-    estimated_amount: Field::Number,
-    billed_amount: Field::Number,
+    order: Field::Number,
     created_at: Field::DateTime,
     updated_at: Field::DateTime,
   }.freeze
@@ -30,23 +23,15 @@ class IAAOrderDashboard < Administrate::BaseDashboard
   # Feel free to add, remove, or rearrange items.
   COLLECTION_ATTRIBUTES = %i[
   name
-  iaa_status
-  end_date
-  billed_amount
+  order
   ].freeze
 
   # SHOW_PAGE_ATTRIBUTES
   # an array of attributes that will be displayed on the model's show page.
   SHOW_PAGE_ATTRIBUTES = %i[
-  iaa_gtc
-  order_number
-  mod_number
-  iaa_status
-  start_date
-  end_date
-  signed_date
-  estimated_amount
-  billed_amount
+  name
+  order
+  accounts
   created_at
   updated_at
   ].freeze
@@ -55,15 +40,8 @@ class IAAOrderDashboard < Administrate::BaseDashboard
   # an array of attributes that will be displayed
   # on the model's form (`new` and `edit`) pages.
   FORM_ATTRIBUTES = %i[
-  iaa_gtc
-  order_number
-  mod_number
-  iaa_status
-  start_date
-  end_date
-  signed_date
-  estimated_amount
-  billed_amount
+  name
+  order
   ].freeze
 
   # COLLECTION_FILTERS
@@ -78,10 +56,10 @@ class IAAOrderDashboard < Administrate::BaseDashboard
   #   }.freeze
   COLLECTION_FILTERS = {}.freeze
 
-  # Overwrite this method to customize how iaa orders are displayed
+  # Overwrite this method to customize how account statuses are displayed
   # across all pages of the admin dashboard.
 
-  def display_resource(iaa_order)
-    "#{iaa_order.name}"
+  def display_resource(account_status)
+    account_status.name
   end
 end

--- a/app/dashboards/iaa_gtc_dashboard.rb
+++ b/app/dashboards/iaa_gtc_dashboard.rb
@@ -14,6 +14,7 @@ class IAAGTCDashboard < Administrate::BaseDashboard
     gtc_number: Field::String,
     mod_number: Field::Number,
     name: Field::String,
+    iaa_status: Field::BelongsTo,
     start_date: Field::Date,
     end_date: Field::Date,
     signed_date: Field::Date,
@@ -30,9 +31,9 @@ class IAAGTCDashboard < Administrate::BaseDashboard
   # Feel free to add, remove, or rearrange items.
   COLLECTION_ATTRIBUTES = %i[
   name
+  iaa_status
   start_date
   end_date
-  account
   ].freeze
 
   # SHOW_PAGE_ATTRIBUTES
@@ -41,6 +42,7 @@ class IAAGTCDashboard < Administrate::BaseDashboard
   account
   gtc_number
   mod_number
+  iaa_status
   start_date
   end_date
   signed_date
@@ -57,6 +59,7 @@ class IAAGTCDashboard < Administrate::BaseDashboard
   account
   gtc_number
   mod_number
+  iaa_status
   start_date
   end_date
   signed_date

--- a/app/dashboards/iaa_status_dashboard.rb
+++ b/app/dashboards/iaa_status_dashboard.rb
@@ -1,6 +1,6 @@
 require "administrate/base_dashboard"
 
-class IAAOrderDashboard < Administrate::BaseDashboard
+class IAAStatusDashboard < Administrate::BaseDashboard
   # ATTRIBUTE_TYPES
   # a hash that describes the type of each of the model's fields.
   #
@@ -8,17 +8,11 @@ class IAAOrderDashboard < Administrate::BaseDashboard
   # which determines how the attribute is displayed
   # on pages throughout the dashboard.
   ATTRIBUTE_TYPES = {
-    iaa_gtc: Field::BelongsTo,
+    iaa_gtcs: Field::HasMany,
+    iaa_orders: Field::HasMany,
     id: Field::Number,
-    order_number: Field::Number,
-    mod_number: Field::Number,
     name: Field::String,
-    iaa_status: Field::BelongsTo,
-    start_date: Field::Date,
-    end_date: Field::Date,
-    signed_date: Field::Date,
-    estimated_amount: Field::Number,
-    billed_amount: Field::Number,
+    order: Field::Number,
     created_at: Field::DateTime,
     updated_at: Field::DateTime,
   }.freeze
@@ -30,23 +24,16 @@ class IAAOrderDashboard < Administrate::BaseDashboard
   # Feel free to add, remove, or rearrange items.
   COLLECTION_ATTRIBUTES = %i[
   name
-  iaa_status
-  end_date
-  billed_amount
+  order
   ].freeze
 
   # SHOW_PAGE_ATTRIBUTES
   # an array of attributes that will be displayed on the model's show page.
   SHOW_PAGE_ATTRIBUTES = %i[
-  iaa_gtc
-  order_number
-  mod_number
-  iaa_status
-  start_date
-  end_date
-  signed_date
-  estimated_amount
-  billed_amount
+  name
+  order
+  iaa_gtcs
+  iaa_orders
   created_at
   updated_at
   ].freeze
@@ -55,15 +42,8 @@ class IAAOrderDashboard < Administrate::BaseDashboard
   # an array of attributes that will be displayed
   # on the model's form (`new` and `edit`) pages.
   FORM_ATTRIBUTES = %i[
-  iaa_gtc
-  order_number
-  mod_number
-  iaa_status
-  start_date
-  end_date
-  signed_date
-  estimated_amount
-  billed_amount
+  name
+  order
   ].freeze
 
   # COLLECTION_FILTERS
@@ -78,10 +58,10 @@ class IAAOrderDashboard < Administrate::BaseDashboard
   #   }.freeze
   COLLECTION_FILTERS = {}.freeze
 
-  # Overwrite this method to customize how iaa orders are displayed
+  # Overwrite this method to customize how iaa statuses are displayed
   # across all pages of the admin dashboard.
 
-  def display_resource(iaa_order)
-    "#{iaa_order.name}"
+  def display_resource(iaa_status)
+    iaa_status.name
   end
 end

--- a/app/dashboards/integration_dashboard.rb
+++ b/app/dashboards/integration_dashboard.rb
@@ -13,6 +13,7 @@ class IntegrationDashboard < Administrate::BaseDashboard
     issuer: Field::String,
     name: Field::String,
     description: Field::Text,
+    integration_status: Field::BelongsTo,
     dashboard_url: Field::String,
     ial2: Field::Boolean,
     protocol: Field::Select.with_options(
@@ -35,7 +36,7 @@ class IntegrationDashboard < Administrate::BaseDashboard
   # Feel free to add, remove, or rearrange items.
   COLLECTION_ATTRIBUTES = %i[
   name
-  protocol
+  integration_status
   account
   issuer
   ].freeze
@@ -47,6 +48,7 @@ class IntegrationDashboard < Administrate::BaseDashboard
   issuer
   name
   description
+  integration_status
   dashboard_url
   ial2
   protocol
@@ -66,6 +68,7 @@ class IntegrationDashboard < Administrate::BaseDashboard
   issuer
   name
   description
+  integration_status
   dashboard_url
   ial2
   protocol

--- a/app/dashboards/integration_status_dashboard.rb
+++ b/app/dashboards/integration_status_dashboard.rb
@@ -1,6 +1,6 @@
 require "administrate/base_dashboard"
 
-class IAAOrderDashboard < Administrate::BaseDashboard
+class IntegrationStatusDashboard < Administrate::BaseDashboard
   # ATTRIBUTE_TYPES
   # a hash that describes the type of each of the model's fields.
   #
@@ -8,17 +8,10 @@ class IAAOrderDashboard < Administrate::BaseDashboard
   # which determines how the attribute is displayed
   # on pages throughout the dashboard.
   ATTRIBUTE_TYPES = {
-    iaa_gtc: Field::BelongsTo,
+    integrations: Field::HasMany,
     id: Field::Number,
-    order_number: Field::Number,
-    mod_number: Field::Number,
     name: Field::String,
-    iaa_status: Field::BelongsTo,
-    start_date: Field::Date,
-    end_date: Field::Date,
-    signed_date: Field::Date,
-    estimated_amount: Field::Number,
-    billed_amount: Field::Number,
+    order: Field::Number,
     created_at: Field::DateTime,
     updated_at: Field::DateTime,
   }.freeze
@@ -30,23 +23,15 @@ class IAAOrderDashboard < Administrate::BaseDashboard
   # Feel free to add, remove, or rearrange items.
   COLLECTION_ATTRIBUTES = %i[
   name
-  iaa_status
-  end_date
-  billed_amount
+  order
   ].freeze
 
   # SHOW_PAGE_ATTRIBUTES
   # an array of attributes that will be displayed on the model's show page.
   SHOW_PAGE_ATTRIBUTES = %i[
-  iaa_gtc
-  order_number
-  mod_number
-  iaa_status
-  start_date
-  end_date
-  signed_date
-  estimated_amount
-  billed_amount
+  name
+  order
+  integrations
   created_at
   updated_at
   ].freeze
@@ -55,15 +40,8 @@ class IAAOrderDashboard < Administrate::BaseDashboard
   # an array of attributes that will be displayed
   # on the model's form (`new` and `edit`) pages.
   FORM_ATTRIBUTES = %i[
-  iaa_gtc
-  order_number
-  mod_number
-  iaa_status
-  start_date
-  end_date
-  signed_date
-  estimated_amount
-  billed_amount
+  name
+  order
   ].freeze
 
   # COLLECTION_FILTERS
@@ -78,10 +56,10 @@ class IAAOrderDashboard < Administrate::BaseDashboard
   #   }.freeze
   COLLECTION_FILTERS = {}.freeze
 
-  # Overwrite this method to customize how iaa orders are displayed
+  # Overwrite this method to customize how integration statuses are displayed
   # across all pages of the admin dashboard.
 
-  def display_resource(iaa_order)
-    "#{iaa_order.name}"
+  def display_resource(integration_status)
+    integration_status.name
   end
 end

--- a/app/models/account.rb
+++ b/app/models/account.rb
@@ -1,4 +1,6 @@
 class Account < ApplicationRecord
+  belongs_to :account_status, optional: true
+
   has_many :account_contacts, dependent: :destroy
   has_many :contacts, through: :account_contacts, source: :user
   has_many :iaa_gtcs, dependent: :destroy

--- a/app/models/account_status.rb
+++ b/app/models/account_status.rb
@@ -1,0 +1,9 @@
+class AccountStatus < ApplicationRecord
+  has_many :accounts, dependent: :nullify
+
+  validates :name, presence: true, uniqueness: { case_sensitive: false }
+  validates :order, presence: true, uniqueness: true
+
+  default_scope { order(:order) }
+  self.implicit_order_column = :order
+end

--- a/app/models/iaa_gtc.rb
+++ b/app/models/iaa_gtc.rb
@@ -1,5 +1,6 @@
 class IAAGTC < ApplicationRecord
   belongs_to :account
+  belongs_to :iaa_status, optional: true
 
   has_many :iaa_orders, dependent: :destroy
 

--- a/app/models/iaa_order.rb
+++ b/app/models/iaa_order.rb
@@ -1,5 +1,6 @@
 class IAAOrder < ApplicationRecord
   belongs_to :iaa_gtc
+  belongs_to :iaa_status, optional: true
 
   validates :order_number, presence: true,
                            numericality: { greater_than: 0 },

--- a/app/models/iaa_status.rb
+++ b/app/models/iaa_status.rb
@@ -1,0 +1,10 @@
+class IAAStatus < ApplicationRecord
+  has_many :iaa_gtcs, dependent: :nullify
+  has_many :iaa_orders, dependent: :nullify
+
+  validates :name, presence: true, uniqueness: { case_sensitive: false }
+  validates :order, presence: true, uniqueness: true
+
+  default_scope { order(:order) }
+  self.implicit_order_column = :order
+end

--- a/app/models/integration.rb
+++ b/app/models/integration.rb
@@ -1,5 +1,6 @@
 class Integration < ApplicationRecord
   belongs_to :account
+  belongs_to :integration_status, optional: true
 
   has_many :integration_contacts, dependent: :destroy
   has_many :contacts, through: :integration_contacts, source: :user

--- a/app/models/integration_status.rb
+++ b/app/models/integration_status.rb
@@ -1,0 +1,9 @@
+class IntegrationStatus < ApplicationRecord
+  has_many :integrations, dependent: :nullify
+
+  validates :name, presence: true, uniqueness: { case_sensitive: false }
+  validates :order, presence: true, uniqueness: true
+
+  default_scope { order(:order) }
+  self.implicit_order_column = :order
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,12 +1,15 @@
 Rails.application.routes.draw do
   namespace :admin do
       resources :accounts
-      resources :account_contacts, only: %i[index show new create destroy]
       resources :iaa_gtcs
       resources :iaa_orders
       resources :integrations
-      resources :integration_contacts, only: %i[index show new create destroy]
       resources :users
+      resources :account_contacts, only: %i[index show new create destroy]
+      resources :integration_contacts, only: %i[index show new create destroy]
+      resources :account_statuses
+      resources :iaa_statuses
+      resources :integration_statuses
 
       root to: "users#index"
     end

--- a/db/migrate/20201106044644_add_iaa_and_integration_statuses.rb
+++ b/db/migrate/20201106044644_add_iaa_and_integration_statuses.rb
@@ -1,0 +1,49 @@
+class AddIAAAndIntegrationStatuses < ActiveRecord::Migration[6.0]
+  def change
+    create_table :account_statuses do |t|
+      t.string :name, null: false
+      t.integer :order, null: false
+
+      t.timestamps
+
+      t.index :name, unique: :true
+      t.index :order, unique: :true
+    end
+
+    change_table :accounts do |t|
+      t.references :account_status, foreign_key: true
+    end
+
+    create_table :iaa_statuses do |t|
+      t.string :name, null: false
+      t.integer :order, null: false
+
+      t.timestamps
+
+      t.index :name, unique: :true
+      t.index :order, unique: :true
+    end
+
+    change_table :iaa_gtcs do |t|
+      t.references :iaa_status, foreign_key: true
+    end
+
+    change_table :iaa_orders do |t|
+      t.references :iaa_status, foreign_key: true
+    end
+
+    create_table :integration_statuses do |t|
+      t.string :name, null: false
+      t.integer :order, null: false
+
+      t.timestamps
+
+      t.index :name, unique: :true
+      t.index :order, unique: :true
+    end
+
+    change_table :integrations do |t|
+      t.references :integration_status, foreign_key: true
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_11_04_224741) do
+ActiveRecord::Schema.define(version: 2020_11_06_044644) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
@@ -26,6 +26,15 @@ ActiveRecord::Schema.define(version: 2020_11_04_224741) do
     t.index ["user_id"], name: "index_account_contacts_on_user_id"
   end
 
+  create_table "account_statuses", force: :cascade do |t|
+    t.string "name", null: false
+    t.integer "order", null: false
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+    t.index ["name"], name: "index_account_statuses_on_name", unique: true
+    t.index ["order"], name: "index_account_statuses_on_order", unique: true
+  end
+
   create_table "accounts", force: :cascade do |t|
     t.string "lg_account_id", null: false
     t.string "name", null: false
@@ -35,6 +44,8 @@ ActiveRecord::Schema.define(version: 2020_11_04_224741) do
     t.date "became_partner"
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
+    t.bigint "account_status_id"
+    t.index ["account_status_id"], name: "index_accounts_on_account_status_id"
   end
 
   create_table "agencies", force: :cascade do |t|
@@ -51,8 +62,10 @@ ActiveRecord::Schema.define(version: 2020_11_04_224741) do
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
     t.integer "mod_number", default: 0, null: false
+    t.bigint "iaa_status_id"
     t.index ["account_id"], name: "index_iaa_gtcs_on_account_id"
     t.index ["gtc_number"], name: "index_iaa_gtcs_on_gtc_number", unique: true
+    t.index ["iaa_status_id"], name: "index_iaa_gtcs_on_iaa_status_id"
   end
 
   create_table "iaa_orders", force: :cascade do |t|
@@ -66,8 +79,19 @@ ActiveRecord::Schema.define(version: 2020_11_04_224741) do
     t.bigint "iaa_gtc_id", null: false
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
+    t.bigint "iaa_status_id"
     t.index ["iaa_gtc_id", "order_number"], name: "index_iaa_orders_on_iaa_gtc_id_and_order_number", unique: true
     t.index ["iaa_gtc_id"], name: "index_iaa_orders_on_iaa_gtc_id"
+    t.index ["iaa_status_id"], name: "index_iaa_orders_on_iaa_status_id"
+  end
+
+  create_table "iaa_statuses", force: :cascade do |t|
+    t.string "name", null: false
+    t.integer "order", null: false
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+    t.index ["name"], name: "index_iaa_statuses_on_name", unique: true
+    t.index ["order"], name: "index_iaa_statuses_on_order", unique: true
   end
 
   create_table "integration_contacts", force: :cascade do |t|
@@ -78,6 +102,15 @@ ActiveRecord::Schema.define(version: 2020_11_04_224741) do
     t.index ["integration_id", "user_id"], name: "index_integration_contacts_on_integration_id_and_user_id", unique: true
     t.index ["integration_id"], name: "index_integration_contacts_on_integration_id"
     t.index ["user_id"], name: "index_integration_contacts_on_user_id"
+  end
+
+  create_table "integration_statuses", force: :cascade do |t|
+    t.string "name", null: false
+    t.integer "order", null: false
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+    t.index ["name"], name: "index_integration_statuses_on_name", unique: true
+    t.index ["order"], name: "index_integration_statuses_on_order", unique: true
   end
 
   create_table "integrations", force: :cascade do |t|
@@ -93,7 +126,9 @@ ActiveRecord::Schema.define(version: 2020_11_04_224741) do
     t.bigint "account_id"
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
+    t.bigint "integration_status_id"
     t.index ["account_id"], name: "index_integrations_on_account_id"
+    t.index ["integration_status_id"], name: "index_integrations_on_integration_status_id"
     t.index ["issuer"], name: "index_integrations_on_issuer", unique: true
   end
 
@@ -116,9 +151,13 @@ ActiveRecord::Schema.define(version: 2020_11_04_224741) do
 
   add_foreign_key "account_contacts", "accounts"
   add_foreign_key "account_contacts", "users"
+  add_foreign_key "accounts", "account_statuses"
   add_foreign_key "iaa_gtcs", "accounts"
+  add_foreign_key "iaa_gtcs", "iaa_statuses"
   add_foreign_key "iaa_orders", "iaa_gtcs"
+  add_foreign_key "iaa_orders", "iaa_statuses"
   add_foreign_key "integration_contacts", "integrations"
   add_foreign_key "integration_contacts", "users"
   add_foreign_key "integrations", "accounts"
+  add_foreign_key "integrations", "integration_statuses"
 end

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -40,6 +40,32 @@ u3 = User.create(
   phone: '202-222-2222',
 )
 
+# Create statuses
+{
+  'intake' => 0,
+  'in progress' => 100,
+  'active' => 200,
+  'lost' => 300
+}.each { |name, order| AccountStatus.create!(name: name, order: order) }
+
+{
+  'intake' => 0,
+  'in progress' => 100,
+  'TTS bizops' => 200,
+  'active' => 300,
+  'expired' => 400,
+  'cancelled' => 500
+}.each { |name, order| IAAStatus.create!(name: name, order: order) }
+
+{
+  'intake' => 0,
+  'in progress' => 100,
+  'config live' => 200,
+  'app live' => 300,
+  'decommissioned' => 400,
+  'cancelled' => 500
+}.each { |name, order| IntegrationStatus.create!(name: name, order: order) }
+
 # a1 = App.create(
 #   lg_app_id: '78937628',
 #   name: 'FMCSA Drug & Alcohol Clearinghouse',

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -9,6 +9,11 @@ FactoryBot.define do
     user
   end
 
+  factory :account_status do
+    name { Faker::Types.rb_string }
+    order { Faker::Types.rb_integer }
+  end
+
   factory :iaa_gtc do
     account
     gtc_number { "LG#{Faker::Name.initials(number: 3)}FY210001" }
@@ -17,6 +22,11 @@ FactoryBot.define do
   factory :iaa_order do
     iaa_gtc
     sequence(:order_number) { |i| i }
+  end
+
+  factory :iaa_status do
+    name { Faker::Types.rb_string }
+    order { Faker::Types.rb_integer }
   end
 
   factory :integration do
@@ -32,6 +42,11 @@ FactoryBot.define do
   factory :integration_contact do
     integration
     user
+  end
+
+  factory :integration_status do
+    name { Faker::Types.rb_string }
+    order { Faker::Types.rb_integer }
   end
 
   factory :user do

--- a/spec/features/administrate/account_contact_dashboard_spec.rb
+++ b/spec/features/administrate/account_contact_dashboard_spec.rb
@@ -23,7 +23,7 @@ RSpec.describe 'Account Contact dashboard', type: :feature do
         select account.name, from: 'Account'
         select user.email, from: 'User'
         click_on 'Create Account contact'
-        expect(page).to have_content('Account contact was successfully created.')
+        expect(page).to have_content('Account Contact was successfully created.')
         # implictly tests the show view since that's where it redirects
       end
     end
@@ -36,7 +36,7 @@ RSpec.describe 'Account Contact dashboard', type: :feature do
         within "tr[data-url=\"#{admin_account_contact_path(account_contact)}\"]" do
           click_on 'Destroy'
         end
-        expect(page).to have_content('Account contact was successfully destroyed.')
+        expect(page).to have_content('Account Contact was successfully destroyed.')
       end
     end
   end

--- a/spec/features/administrate/account_status_dashboard_spec.rb
+++ b/spec/features/administrate/account_status_dashboard_spec.rb
@@ -1,0 +1,54 @@
+require 'rails_helper'
+
+RSpec.describe 'Account Status dashboard', type: :feature do
+  context 'as an admin' do
+    let(:admin) { create(:user, admin: true) }
+
+    before { sign_in_with_warden(admin) }
+
+    describe 'index' do
+      it 'works' do
+        visit admin_account_statuses_path
+        expect(page).to have_content('Back to app')
+      end
+    end
+
+    describe 'create' do
+      it 'works' do
+        visit admin_account_statuses_path
+        click_on 'New Account Status'
+        fill_in 'Name', with: 'pending'
+        fill_in 'Order', with: 0
+        click_on 'Create Account status'
+        expect(page).to have_content('Account Status was successfully created.')
+        # implictly tests the show view since that's where it redirects
+      end
+    end
+
+    describe 'update' do
+      let(:old_name) { 'pending' }
+      let(:new_name) { 'soon to be' }
+      let(:account_status) { create(:account_status, name: old_name) }
+
+      it 'works' do
+        visit admin_account_status_path(account_status)
+        click_on "Edit #{account_status.name}"
+        fill_in 'Name', with: new_name
+        click_on 'Update Account status'
+        expect(page).to have_content('Account Status was successfully updated.')
+      end
+    end
+
+    describe 'destroy' do
+      let!(:account_status) { create(:account_status) }
+
+      it 'works' do
+        visit admin_account_statuses_path
+        within "tr[data-url=\"#{admin_account_status_path(account_status)}\"]" do
+          click_on 'Destroy'
+        end
+        expect(page).to have_content('Account Status was successfully destroyed.')
+      end
+    end
+  end
+end

--- a/spec/features/administrate/iaa_status_dashboard_spec.rb
+++ b/spec/features/administrate/iaa_status_dashboard_spec.rb
@@ -1,0 +1,54 @@
+require 'rails_helper'
+
+RSpec.describe 'IAA Status dashboard', type: :feature do
+  context 'as an admin' do
+    let(:admin) { create(:user, admin: true) }
+
+    before { sign_in_with_warden(admin) }
+
+    describe 'index' do
+      it 'works' do
+        visit admin_iaa_statuses_path
+        expect(page).to have_content('Back to app')
+      end
+    end
+
+    describe 'create' do
+      it 'works' do
+        visit admin_iaa_statuses_path
+        click_on 'New IAA Status'
+        fill_in 'Name', with: 'pending'
+        fill_in 'Order', with: 0
+        click_on 'Create IAA status'
+        expect(page).to have_content('IAA Status was successfully created.')
+        # implictly tests the show view since that's where it redirects
+      end
+    end
+
+    describe 'update' do
+      let(:old_name) { 'pending' }
+      let(:new_name) { 'soon to be' }
+      let(:iaa_status) { create(:iaa_status, name: old_name) }
+
+      it 'works' do
+        visit admin_iaa_status_path(iaa_status)
+        click_on "Edit #{iaa_status.name}"
+        fill_in 'Name', with: new_name
+        click_on 'Update IAA status'
+        expect(page).to have_content('IAA Status was successfully updated.')
+      end
+    end
+
+    describe 'destroy' do
+      let!(:iaa_status) { create(:iaa_status) }
+
+      it 'works' do
+        visit admin_iaa_statuses_path
+        within "tr[data-url=\"#{admin_iaa_status_path(iaa_status)}\"]" do
+          click_on 'Destroy'
+        end
+        expect(page).to have_content('IAA Status was successfully destroyed.')
+      end
+    end
+  end
+end

--- a/spec/features/administrate/integration_contact_dashboard_spec.rb
+++ b/spec/features/administrate/integration_contact_dashboard_spec.rb
@@ -23,7 +23,7 @@ RSpec.describe 'Integration Contact dashboard', type: :feature do
         select integration.name, from: 'Integration'
         select user.email, from: 'User'
         click_on 'Create Integration contact'
-        expect(page).to have_content('Integration contact was successfully created.')
+        expect(page).to have_content('Integration Contact was successfully created.')
         # implictly tests the show view since that's where it redirects
       end
     end
@@ -36,7 +36,7 @@ RSpec.describe 'Integration Contact dashboard', type: :feature do
         within "tr[data-url=\"#{admin_integration_contact_path(integration_contact)}\"]" do
           click_on 'Destroy'
         end
-        expect(page).to have_content('Integration contact was successfully destroyed.')
+        expect(page).to have_content('Integration Contact was successfully destroyed.')
       end
     end
   end

--- a/spec/features/administrate/integration_status_dashboard_spec.rb
+++ b/spec/features/administrate/integration_status_dashboard_spec.rb
@@ -1,0 +1,54 @@
+require 'rails_helper'
+
+RSpec.describe 'Integration Status dashboard', type: :feature do
+  context 'as an admin' do
+    let(:admin) { create(:user, admin: true) }
+
+    before { sign_in_with_warden(admin) }
+
+    describe 'index' do
+      it 'works' do
+        visit admin_integration_statuses_path
+        expect(page).to have_content('Back to app')
+      end
+    end
+
+    describe 'create' do
+      it 'works' do
+        visit admin_integration_statuses_path
+        click_on 'New Integration Status'
+        fill_in 'Name', with: 'pending'
+        fill_in 'Order', with: 0
+        click_on 'Create Integration status'
+        expect(page).to have_content('Integration Status was successfully created.')
+        # implictly tests the show view since that's where it redirects
+      end
+    end
+
+    describe 'update' do
+      let(:old_name) { 'pending' }
+      let(:new_name) { 'soon to be' }
+      let(:integration_status) { create(:integration_status, name: old_name) }
+
+      it 'works' do
+        visit admin_integration_status_path(integration_status)
+        click_on "Edit #{integration_status.name}"
+        fill_in 'Name', with: new_name
+        click_on 'Update Integration status'
+        expect(page).to have_content('Integration Status was successfully updated.')
+      end
+    end
+
+    describe 'destroy' do
+      let!(:integration_status) { create(:integration_status) }
+
+      it 'works' do
+        visit admin_integration_statuses_path
+        within "tr[data-url=\"#{admin_integration_status_path(integration_status)}\"]" do
+          click_on 'Destroy'
+        end
+        expect(page).to have_content('Integration Status was successfully destroyed.')
+      end
+    end
+  end
+end

--- a/spec/models/account_spec.rb
+++ b/spec/models/account_spec.rb
@@ -12,6 +12,7 @@ RSpec.describe Account, type: :model do
   describe 'associations' do
     subject { build(:account) }
 
+    it { is_expected.to belong_to(:account_status).optional }
     it { is_expected.to have_many(:account_contacts).dependent(:destroy) }
     it { is_expected.to have_many(:contacts).through(:account_contacts).source(:user) }
     it { is_expected.to have_many(:iaa_gtcs).dependent(:destroy) }

--- a/spec/models/account_status_spec.rb
+++ b/spec/models/account_status_spec.rb
@@ -1,0 +1,29 @@
+require 'rails_helper'
+
+RSpec.describe AccountStatus, type: :model do
+  describe 'validations' do
+    subject { build(:account_status) }
+
+    it { is_expected.to validate_presence_of(:name) }
+    it { is_expected.to validate_uniqueness_of(:name).case_insensitive }
+    it { is_expected.to validate_presence_of(:order) }
+    it { is_expected.to validate_uniqueness_of(:order) }
+  end
+
+  describe 'associations' do
+    subject { build(:account_status) }
+
+    it { is_expected.to have_many(:accounts).dependent(:nullify) }
+  end
+
+  describe 'ordering' do
+    it { is_expected.to have_implicit_order_column(:order) }
+
+    it 'orders by the "order" column by default' do
+      create(:account_status, name: 'foo', order: 100)
+      create(:account_status, name: 'bar', order: 0)
+
+      expect(described_class.pluck(:name)).to eq(%w[bar foo])
+    end
+  end
+end

--- a/spec/models/iaa_gtc_spec.rb
+++ b/spec/models/iaa_gtc_spec.rb
@@ -15,6 +15,7 @@ RSpec.describe IAAGTC, type: :model do
     subject { build(:iaa_gtc) }
 
     it { is_expected.to belong_to(:account) }
+    it { is_expected.to belong_to(:iaa_status).optional }
     it { is_expected.to have_many(:iaa_orders).dependent(:destroy) }
   end
 

--- a/spec/models/iaa_order_spec.rb
+++ b/spec/models/iaa_order_spec.rb
@@ -23,6 +23,7 @@ RSpec.describe IAAOrder, type: :model do
 
   describe 'associations' do
     it { is_expected.to belong_to(:iaa_gtc) }
+    it { is_expected.to belong_to(:iaa_status).optional }
   end
 
   describe '#name' do

--- a/spec/models/iaa_status_spec.rb
+++ b/spec/models/iaa_status_spec.rb
@@ -1,0 +1,30 @@
+require 'rails_helper'
+
+RSpec.describe IAAStatus, type: :model do
+  describe 'validations' do
+    subject { build(:iaa_status) }
+
+    it { is_expected.to validate_presence_of(:name) }
+    it { is_expected.to validate_uniqueness_of(:name).case_insensitive }
+    it { is_expected.to validate_presence_of(:order) }
+    it { is_expected.to validate_uniqueness_of(:order) }
+  end
+
+  describe 'associations' do
+    subject { build(:iaa_status) }
+
+    it { is_expected.to have_many(:iaa_gtcs).dependent(:nullify) }
+    it { is_expected.to have_many(:iaa_orders).dependent(:nullify) }
+  end
+
+  describe 'ordering' do
+    it { is_expected.to have_implicit_order_column(:order) }
+
+    it 'orders by the "order" column by default' do
+      create(:iaa_status, name: 'foo', order: 100)
+      create(:iaa_status, name: 'bar', order: 0)
+
+      expect(described_class.pluck(:name)).to eq(%w[bar foo])
+    end
+  end
+end

--- a/spec/models/integration_spec.rb
+++ b/spec/models/integration_spec.rb
@@ -15,6 +15,7 @@ RSpec.describe Integration, type: :model do
     subject { build(:integration) }
 
     it { is_expected.to belong_to(:account) }
+    it { is_expected.to belong_to(:integration_status).optional }
     it { is_expected.to have_many(:integration_contacts).dependent(:destroy) }
     it { is_expected.to have_many(:contacts).through(:integration_contacts).source(:user) }
   end

--- a/spec/models/integration_status_spec.rb
+++ b/spec/models/integration_status_spec.rb
@@ -1,0 +1,29 @@
+require 'rails_helper'
+
+RSpec.describe IntegrationStatus, type: :model do
+  describe 'validations' do
+    subject { build(:integration_status) }
+
+    it { is_expected.to validate_presence_of(:name) }
+    it { is_expected.to validate_uniqueness_of(:name).case_insensitive }
+    it { is_expected.to validate_presence_of(:order) }
+    it { is_expected.to validate_uniqueness_of(:order) }
+  end
+
+  describe 'associations' do
+    subject { build(:integration_status) }
+
+    it { is_expected.to have_many(:integrations).dependent(:nullify) }
+  end
+
+  describe 'ordering' do
+    it { is_expected.to have_implicit_order_column(:order) }
+
+    it 'orders by the "order" column by default' do
+      create(:integration_status, name: 'foo', order: 100)
+      create(:integration_status, name: 'bar', order: 0)
+
+      expect(described_class.pluck(:name)).to eq(%w[bar foo])
+    end
+  end
+end


### PR DESCRIPTION
Creates a set of three lookup tables to allow for flexible management of
enumerated status values for Accounts, IAAGTCs, IAAOrders, and
Integrations. IAAGTCs and IAAOrders share the same set of statuses. Each
lookup table record consists of a unique name and a unique integer
order, the latter of which is used to determine the display order of
statuses in dropdowns.

I originally attempted to "be fancy" and have all of the `belongs_to`
associations named `:status` and use additional parameters to identify
the class_name and foreign key, but this made things messier than they
needed to be and in the worst case we should be able to eventually
override the attribute labels if we need to. Therefore everything here
ended up pretty vanilla.

This also includes some minor changes to the flash message overrides in
the IntegrationContact and AccountContact controllers for (slightly)
more consistent capitalization.