### PR TITLE
Fix missing inflection for migration

### DIFF
--- a/config/initializers/inflections.rb
+++ b/config/initializers/inflections.rb
@@ -2,6 +2,7 @@ ActiveSupport::Inflector.inflections(:en) do |inflect|
   inflect.acronym('GTC')
   inflect.acronym('GTCs')
   inflect.acronym('IAA')
+  inflect.acronym('IAAs')
   inflect.acronym('IAL2')
   inflect.acronym('URL')
 end


### PR DESCRIPTION
While we no longer have a plain `IAA` model, we have a migration called
`CreateIAAs` and without the plural inflection `db:migrate` failed
during deployment. Adding the plural inflection back in to fix this.