### PR TITLE
Revamp Agency model

### DIFF
--- a/app/controllers/admin/agencies_controller.rb
+++ b/app/controllers/admin/agencies_controller.rb
@@ -1,0 +1,46 @@
+module Admin
+  class AgenciesController < Admin::ApplicationController
+    # Overwrite any of the RESTful controller actions to implement custom behavior
+    # For example, you may want to send an email after a foo is updated.
+    #
+    # def update
+    #   super
+    #   send_foo_updated_email(requested_resource)
+    # end
+
+    # Override this method to specify custom lookup behavior.
+    # This will be used to set the resource for the `show`, `edit`, and `update`
+    # actions.
+    #
+    # def find_resource(param)
+    #   Foo.find_by!(slug: param)
+    # end
+
+    # The result of this lookup will be available as `requested_resource`
+
+    # Override this if you have certain roles that require a subset
+    # this will be used to set the records shown on the `index` action.
+    #
+    # def scoped_resource
+    #   if current_user.super_admin?
+    #     resource_class
+    #   else
+    #     resource_class.with_less_stuff
+    #   end
+    # end
+
+    # Override `resource_params` if you want to transform the submitted
+    # data before it's persisted. For example, the following would turn all
+    # empty values into nil values. It uses other APIs such as `resource_class`
+    # and `dashboard`:
+    #
+    # def resource_params
+    #   params.require(resource_class.model_name.param_key).
+    #     permit(dashboard.permitted_attributes).
+    #     transform_values { |value| value == "" ? nil : value }
+    # end
+
+    # See https://administrate-prototype.herokuapp.com/customizing_controller_actions
+    # for more information
+  end
+end

--- a/app/dashboards/agency_dashboard.rb
+++ b/app/dashboards/agency_dashboard.rb
@@ -1,6 +1,6 @@
 require "administrate/base_dashboard"
 
-class AccountDashboard < Administrate::BaseDashboard
+class AgencyDashboard < Administrate::BaseDashboard
   # ATTRIBUTE_TYPES
   # a hash that describes the type of each of the model's fields.
   #
@@ -8,19 +8,13 @@ class AccountDashboard < Administrate::BaseDashboard
   # which determines how the attribute is displayed
   # on pages throughout the dashboard.
   ATTRIBUTE_TYPES = {
+    accounts: Field::HasMany,
     id: Field::Number,
-    lg_identifier: Field::String,
     name: Field::String,
-    description: Field::Text,
-    account_status: Field::BelongsTo,
+    lg_identifier: Field::Number,
+    abbreviation: Field::String,
     created_at: Field::DateTime,
     updated_at: Field::DateTime,
-    agency: Field::BelongsTo,
-    iaa_gtcs: Field::HasMany,
-    iaa_orders: Field::HasMany,
-    account_contacts: Field::HasMany,
-    contacts: Field::HasMany.with_options(class_name: 'User'),
-    integrations: Field::HasMany
   }.freeze
 
   # COLLECTION_ATTRIBUTES
@@ -29,24 +23,18 @@ class AccountDashboard < Administrate::BaseDashboard
   # By default, it's limited to four items to reduce clutter on index pages.
   # Feel free to add, remove, or rearrange items.
   COLLECTION_ATTRIBUTES = %i[
-  lg_identifier
   name
-  agency
-  account_status
+  abbreviation
+  lg_identifier
   ].freeze
 
   # SHOW_PAGE_ATTRIBUTES
   # an array of attributes that will be displayed on the model's show page.
   SHOW_PAGE_ATTRIBUTES = %i[
-  lg_identifier
   name
-  description
-  agency
-  account_status
-  iaa_gtcs
-  iaa_orders
-  integrations
-  account_contacts
+  abbreviation
+  lg_identifier
+  accounts
   created_at
   updated_at
   ].freeze
@@ -55,11 +43,9 @@ class AccountDashboard < Administrate::BaseDashboard
   # an array of attributes that will be displayed
   # on the model's form (`new` and `edit`) pages.
   FORM_ATTRIBUTES = %i[
-  lg_identifier
   name
-  description
-  agency
-  account_status
+  abbreviation
+  lg_identifier
   ].freeze
 
   # COLLECTION_FILTERS
@@ -74,10 +60,10 @@ class AccountDashboard < Administrate::BaseDashboard
   #   }.freeze
   COLLECTION_FILTERS = {}.freeze
 
-  # Overwrite this method to customize how accounts are displayed
+  # Overwrite this method to customize how agencies are displayed
   # across all pages of the admin dashboard.
-  #
-  def display_resource(account)
-    "#{account.name}"
+
+  def display_resource(agency)
+    "#{agency.name}"
   end
 end

--- a/app/models/account.rb
+++ b/app/models/account.rb
@@ -1,5 +1,6 @@
 class Account < ApplicationRecord
   belongs_to :account_status, optional: true
+  belongs_to :agency
 
   has_many :account_contacts, dependent: :destroy
   has_many :contacts, through: :account_contacts, source: :user
@@ -7,7 +8,7 @@ class Account < ApplicationRecord
   has_many :iaa_orders, through: :iaa_gtcs
   has_many :integrations, dependent: :destroy
 
-  validates :lg_account_id, presence: true,
+  validates :lg_identifier, presence: true,
                             uniqueness: { case_sensitive: false }
   validates :name, presence: true
 end

--- a/app/models/agency.rb
+++ b/app/models/agency.rb
@@ -1,2 +1,11 @@
 class Agency < ApplicationRecord
+  has_many :accounts
+
+  validates :abbreviation, presence: true,
+                           uniqueness: { case_sensitive: false }
+  validates :lg_identifier, presence: true,
+                            uniqueness: true,
+                            numericality: { greater_than: 0 }
+  validates :name, presence: true,
+                   uniqueness: { case_sensitive: false }
 end

--- a/config/initializers/inflections.rb
+++ b/config/initializers/inflections.rb
@@ -4,6 +4,7 @@ ActiveSupport::Inflector.inflections(:en) do |inflect|
   inflect.acronym('IAA')
   inflect.acronym('IAAs')
   inflect.acronym('IAL2')
+  inflect.acronym('LG')
   inflect.acronym('URL')
 end
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -7,6 +7,7 @@ Rails.application.routes.draw do
       resources :users
       resources :account_contacts, only: %i[index show new create destroy]
       resources :integration_contacts, only: %i[index show new create destroy]
+      resources :agencies
       resources :account_statuses
       resources :iaa_statuses
       resources :integration_statuses

--- a/db/migrate/20201111022657_revamp_agencies.rb
+++ b/db/migrate/20201111022657_revamp_agencies.rb
@@ -1,0 +1,31 @@
+class RevampAgencies < ActiveRecord::Migration[6.0]
+  def change
+    change_table :agencies do |t|
+      t.integer :lg_identifier, null: false
+      t.string :abbreviation, null: false
+
+      t.timestamps
+
+      t.index :lg_identifier, unique: true
+      t.index :abbreviation, unique: true
+      t.index :name, unique: true
+    end
+
+    change_table :accounts do |t|
+      t.references :agency, foreign_key: true
+    end
+
+    rename_column :accounts, :lg_account_id, :lg_identifier
+    add_index :accounts, :lg_identifier, unique: true
+
+    reversible do |dir|
+      dir.up do
+        remove_column :accounts, :lg_agency_id
+      end
+
+      dir.down do
+        add_column :accounts, :lg_agency_id, :integer
+      end
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_11_06_044644) do
+ActiveRecord::Schema.define(version: 2020_11_11_022657) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
@@ -36,20 +36,29 @@ ActiveRecord::Schema.define(version: 2020_11_06_044644) do
   end
 
   create_table "accounts", force: :cascade do |t|
-    t.string "lg_account_id", null: false
+    t.string "lg_identifier", null: false
     t.string "name", null: false
     t.text "description"
-    t.integer "lg_agency_id"
     t.integer "pricing"
     t.date "became_partner"
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
     t.bigint "account_status_id"
+    t.bigint "agency_id"
     t.index ["account_status_id"], name: "index_accounts_on_account_status_id"
+    t.index ["agency_id"], name: "index_accounts_on_agency_id"
+    t.index ["lg_identifier"], name: "index_accounts_on_lg_identifier", unique: true
   end
 
   create_table "agencies", force: :cascade do |t|
     t.string "name", null: false
+    t.integer "lg_identifier", null: false
+    t.string "abbreviation", null: false
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+    t.index ["abbreviation"], name: "index_agencies_on_abbreviation", unique: true
+    t.index ["lg_identifier"], name: "index_agencies_on_lg_identifier", unique: true
+    t.index ["name"], name: "index_agencies_on_name", unique: true
   end
 
   create_table "iaa_gtcs", force: :cascade do |t|
@@ -152,6 +161,7 @@ ActiveRecord::Schema.define(version: 2020_11_06_044644) do
   add_foreign_key "account_contacts", "accounts"
   add_foreign_key "account_contacts", "users"
   add_foreign_key "accounts", "account_statuses"
+  add_foreign_key "accounts", "agencies"
   add_foreign_key "iaa_gtcs", "accounts"
   add_foreign_key "iaa_gtcs", "iaa_statuses"
   add_foreign_key "iaa_orders", "iaa_gtcs"

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -1,7 +1,19 @@
 FactoryBot.define do
+  factory :agency do
+    lg_identifier { Faker::Types.rb_integer }
+    abbreviation { Faker::Name.initials(number: 3) }
+    name do
+      [
+        "Department of #{Faker::Commerce.department}",
+        "National #{Faker::Commerce.department} Agency"
+      ].sample
+    end
+  end
+
   factory :account do
-    lg_account_id { "LG-E-#{Faker::Name.initials(number: 3)}" }
-    name { lg_account_id.split('-').last }
+    agency
+    lg_identifier { "LG-E-#{Faker::Name.initials(number: 3)}" }
+    name { lg_identifier.split('-').last }
   end
 
   factory :account_contact do

--- a/spec/features/administrate/account_dashboard_spec.rb
+++ b/spec/features/administrate/account_dashboard_spec.rb
@@ -14,10 +14,13 @@ RSpec.describe 'Account dashboard', type: :feature do
     end
 
     describe 'create' do
+      let!(:agency) { create(:agency) }
+
       it 'works' do
         visit admin_accounts_path
         click_on 'New Account'
-        fill_in 'Lg account', with: 'LG-E-FOO'
+        select agency.name, from: 'Agency'
+        fill_in 'LG identifier', with: 'LG-E-FOO'
         fill_in 'Name', with: 'Federal Office of Operations'
         click_on 'Create Account'
         expect(page).to have_content('Account was successfully created.')

--- a/spec/features/administrate/agency_dashboard_spec.rb
+++ b/spec/features/administrate/agency_dashboard_spec.rb
@@ -1,0 +1,55 @@
+require 'rails_helper'
+
+RSpec.describe 'Agency dashboard', type: :feature do
+  context 'as an admin' do
+    let(:admin) { create(:user, admin: true) }
+
+    before { sign_in_with_warden(admin) }
+
+    describe 'index' do
+      it 'works' do
+        visit admin_agencies_path
+        expect(page).to have_content('Back to app')
+      end
+    end
+
+    describe 'create' do
+      it 'works' do
+        visit admin_agencies_path
+        click_on 'New Agency'
+        fill_in 'Name', with: 'General Widgets Administration'
+        fill_in 'Abbreviation', with: 'GWA'
+        fill_in 'LG identifier', with: 1
+        click_on 'Create Agency'
+        expect(page).to have_content('Agency was successfully created.')
+        # implictly tests the show view since that's where it redirects
+      end
+    end
+
+    describe 'update' do
+      let(:old_name) { 'Bureau of Amazing Resources' }
+      let(:new_name) { 'Bureau of Awesome Resources' }
+      let(:agency) { create(:agency, name: old_name) }
+
+      it 'works' do
+        visit admin_agency_path(agency)
+        click_on "Edit #{agency.name}"
+        fill_in 'Name', with: new_name
+        click_on 'Update Agency'
+        expect(page).to have_content('Agency was successfully updated.')
+      end
+    end
+
+    describe 'destroy' do
+      let!(:agency) { create(:agency) }
+
+      it 'works' do
+        visit admin_agencies_path
+        within "tr[data-url=\"#{admin_agency_path(agency)}\"]" do
+          click_on 'Destroy'
+        end
+        expect(page).to have_content('Agency was successfully destroyed.')
+      end
+    end
+  end
+end

--- a/spec/models/account_spec.rb
+++ b/spec/models/account_spec.rb
@@ -4,8 +4,8 @@ RSpec.describe Account, type: :model do
   describe 'validations' do
     subject { build(:account) }
 
-    it { is_expected.to validate_presence_of(:lg_account_id) }
-    it { is_expected.to validate_uniqueness_of(:lg_account_id).case_insensitive }
+    it { is_expected.to validate_presence_of(:lg_identifier) }
+    it { is_expected.to validate_uniqueness_of(:lg_identifier).case_insensitive }
     it { is_expected.to validate_presence_of(:name) }
   end
 
@@ -13,6 +13,7 @@ RSpec.describe Account, type: :model do
     subject { build(:account) }
 
     it { is_expected.to belong_to(:account_status).optional }
+    it { is_expected.to belong_to(:agency) }
     it { is_expected.to have_many(:account_contacts).dependent(:destroy) }
     it { is_expected.to have_many(:contacts).through(:account_contacts).source(:user) }
     it { is_expected.to have_many(:iaa_gtcs).dependent(:destroy) }

--- a/spec/models/agency_spec.rb
+++ b/spec/models/agency_spec.rb
@@ -1,0 +1,21 @@
+require 'rails_helper'
+
+RSpec.describe Agency, type: :model do
+  describe 'validations' do
+    subject { build(:agency) }
+
+    it { is_expected.to validate_presence_of(:abbreviation) }
+    it { is_expected.to validate_uniqueness_of(:abbreviation).case_insensitive }
+    it { is_expected.to validate_presence_of(:lg_identifier) }
+    it { is_expected.to validate_uniqueness_of(:lg_identifier) }
+    it { is_expected.to validate_numericality_of(:lg_identifier).is_greater_than(0) }
+    it { is_expected.to validate_presence_of(:name) }
+    it { is_expected.to validate_uniqueness_of(:name).case_insensitive }
+  end
+
+  describe 'associations' do
+    subject { build(:agency) }
+
+    it { is_expected.to have_many(:accounts) }
+  end
+end


### PR DESCRIPTION
- Rename `lg_account_id` attribute to `lg_identifier` to avoid the Rails
  form helper filtering out the `ID` part of the attribute and for
  consistency across models. Also add unique index to accounts table.