### PR TITLE
Add tracking of current usage for IAA Orders

### DIFF
--- a/app/controllers/admin/integration_usages_controller.rb
+++ b/app/controllers/admin/integration_usages_controller.rb
@@ -1,0 +1,58 @@
+module Admin
+  class IntegrationUsagesController < Admin::ApplicationController
+    # Overwrite any of the RESTful controller actions to implement custom behavior
+    # For example, you may want to send an email after a foo is updated.
+    #
+    # def update
+    #   super
+    #   send_foo_updated_email(requested_resource)
+    # end
+
+    # Override this method to specify custom lookup behavior.
+    # This will be used to set the resource for the `show`, `edit`, and `update`
+    # actions.
+    #
+    # def find_resource(param)
+    #   Foo.find_by!(slug: param)
+    # end
+
+    # The result of this lookup will be available as `requested_resource`
+
+    # Override this if you have certain roles that require a subset
+    # this will be used to set the records shown on the `index` action.
+    #
+    # def scoped_resource
+    #   if current_user.super_admin?
+    #     resource_class
+    #   else
+    #     resource_class.with_less_stuff
+    #   end
+    # end
+
+    # Override `resource_params` if you want to transform the submitted
+    # data before it's persisted. For example, the following would turn all
+    # empty values into nil values. It uses other APIs such as `resource_class`
+    # and `dashboard`:
+    #
+    # def resource_params
+    #   params.require(resource_class.model_name.param_key).
+    #     permit(dashboard.permitted_attributes).
+    #     transform_values { |value| value == "" ? nil : value }
+    # end
+
+    # See https://administrate-prototype.herokuapp.com/customizing_controller_actions
+    # for more information
+
+    private
+
+    # Need to override the resource name since both parts of the name are
+    # acronyms and Administrate turns them into "IAAOrder".
+    # See https://github.com/thoughtbot/administrate/issues/1819
+    def translate_with_resource(key)
+      t(
+        "administrate.controller.#{key}",
+        resource: 'Integration Usage',
+      )
+    end
+  end
+end

--- a/app/dashboards/integration_dashboard.rb
+++ b/app/dashboards/integration_dashboard.rb
@@ -25,6 +25,7 @@ class IntegrationDashboard < Administrate::BaseDashboard
     prod_deploy: Field::Date,
     contacts: Field::HasMany.with_options(class_name: 'User'),
     integration_contacts: Field::HasMany,
+    integration_usages: Field::HasMany,
     created_at: Field::DateTime,
     updated_at: Field::DateTime,
   }.freeze
@@ -55,6 +56,7 @@ class IntegrationDashboard < Administrate::BaseDashboard
   url
   go_live
   prod_deploy
+  integration_usages
   integration_contacts
   created_at
   updated_at

--- a/app/dashboards/integration_usage_dashboard.rb
+++ b/app/dashboards/integration_usage_dashboard.rb
@@ -1,6 +1,6 @@
 require "administrate/base_dashboard"
 
-class IAAOrderDashboard < Administrate::BaseDashboard
+class IntegrationUsageDashboard < Administrate::BaseDashboard
   # ATTRIBUTE_TYPES
   # a hash that describes the type of each of the model's fields.
   #
@@ -8,20 +8,10 @@ class IAAOrderDashboard < Administrate::BaseDashboard
   # which determines how the attribute is displayed
   # on pages throughout the dashboard.
   ATTRIBUTE_TYPES = {
-    iaa_gtc: Field::BelongsTo,
+    iaa_order: Field::BelongsTo,
+    integration: Field::BelongsTo,
     id: Field::Number,
-    order_number: Field::Number,
-    mod_number: Field::Number,
-    name: Field::String,
-    iaa_status: Field::BelongsTo,
-    start_date: Field::Date,
-    end_date: Field::Date,
-    signed_date: Field::Date,
-    estimated_amount: Field::Number,
-    platform_fee: Field::Number,
-    ial2_users: Field::Number,
-    cost_to_date: Field::Number,
-    integration_usages: Field::HasMany,
+    auths: Field::Number,
     created_at: Field::DateTime,
     updated_at: Field::DateTime,
   }.freeze
@@ -32,27 +22,17 @@ class IAAOrderDashboard < Administrate::BaseDashboard
   # By default, it's limited to four items to reduce clutter on index pages.
   # Feel free to add, remove, or rearrange items.
   COLLECTION_ATTRIBUTES = %i[
-  name
-  iaa_status
-  end_date
-  cost_to_date
+  iaa_order
+  integration
+  auths
   ].freeze
 
   # SHOW_PAGE_ATTRIBUTES
   # an array of attributes that will be displayed on the model's show page.
   SHOW_PAGE_ATTRIBUTES = %i[
-  iaa_gtc
-  order_number
-  mod_number
-  iaa_status
-  start_date
-  end_date
-  signed_date
-  estimated_amount
-  cost_to_date
-  platform_fee
-  ial2_users
-  integration_usages
+  iaa_order
+  integration
+  auths
   created_at
   updated_at
   ].freeze
@@ -61,16 +41,9 @@ class IAAOrderDashboard < Administrate::BaseDashboard
   # an array of attributes that will be displayed
   # on the model's form (`new` and `edit`) pages.
   FORM_ATTRIBUTES = %i[
-  iaa_gtc
-  order_number
-  mod_number
-  iaa_status
-  start_date
-  end_date
-  signed_date
-  estimated_amount
-  platform_fee
-  ial2_users
+  iaa_order
+  integration
+  auths
   ].freeze
 
   # COLLECTION_FILTERS
@@ -85,10 +58,10 @@ class IAAOrderDashboard < Administrate::BaseDashboard
   #   }.freeze
   COLLECTION_FILTERS = {}.freeze
 
-  # Overwrite this method to customize how iaa orders are displayed
+  # Overwrite this method to customize how integration usages are displayed
   # across all pages of the admin dashboard.
 
-  def display_resource(iaa_order)
-    "#{iaa_order.name}"
+  def display_resource(integration_usage)
+    "Integration Usage ##{integration_usage.id}"
   end
 end

--- a/app/models/agency.rb
+++ b/app/models/agency.rb
@@ -1,5 +1,5 @@
 class Agency < ApplicationRecord
-  has_many :accounts
+  has_many :accounts, dependent: :nullify
 
   validates :abbreviation, presence: true,
                            uniqueness: { case_sensitive: false }

--- a/app/models/iaa_order.rb
+++ b/app/models/iaa_order.rb
@@ -2,15 +2,19 @@ class IAAOrder < ApplicationRecord
   belongs_to :iaa_gtc
   belongs_to :iaa_status, optional: true
 
+  has_many :integration_usages, dependent: :destroy
+
   validates :order_number, presence: true,
                            numericality: { greater_than: 0 },
                            uniqueness: { scope: :iaa_gtc }
   validates :mod_number, presence: true,
                          numericality: { greater_than_or_equal_to: 0 }
-  validates :estimated_amount, numericality: { greater_than_or_equal_to: 0,
-                                               allow_nil: true }
-  validates :billed_amount, numericality: { greater_than_or_equal_to: 0,
-                                            allow_nil: true }
+  validates :estimated_amount, presence: true,
+                               numericality: { greater_than_or_equal_to: 0 }
+  validates :platform_fee, presence: true,
+                           numericality: { greater_than_or_equal_to: 0 }
+  validates :ial2_users, presence: true,
+                         numericality: { greater_than_or_equal_to: 0 }
 
   delegate :gtc_number, to: :iaa_gtc
 
@@ -21,6 +25,17 @@ class IAAOrder < ApplicationRecord
   # @return [String] the official 7600B name
   def name
     "#{gtc_number}-#{name_str(order_number)}-#{name_str(mod_number)}"
+  end
+
+  # Returns the estimated amount obligated based on the platform fee and entered
+  # usage across the associated integrations. Pricing parameters are managed in
+  # the environment
+  def cost_to_date
+    total_auths = integration_usages.pluck(:auths).sum
+    auth_cost = total_auths * Figaro.env.per_auth_cost.to_f
+    ial2_user_cost = ial2_users * Figaro.env.per_ial2_user_cost.to_f
+
+    platform_fee + auth_cost + ial2_user_cost
   end
 
   private

--- a/app/models/integration.rb
+++ b/app/models/integration.rb
@@ -4,6 +4,7 @@ class Integration < ApplicationRecord
 
   has_many :integration_contacts, dependent: :destroy
   has_many :contacts, through: :integration_contacts, source: :user
+  has_many :integration_usages, dependent: :nullify
 
   validates :issuer, presence: true,
                      uniqueness: { case_sensitive: false }

--- a/app/models/integration_usage.rb
+++ b/app/models/integration_usage.rb
@@ -1,0 +1,7 @@
+class IntegrationUsage < ApplicationRecord
+  belongs_to :iaa_order
+  belongs_to :integration
+
+  validates :auths, presence: true,
+                    numericality: { greater_than_or_equal_to: 0 }
+end

--- a/app/views/accounts/_my_account.html.erb
+++ b/app/views/accounts/_my_account.html.erb
@@ -59,7 +59,7 @@
           <th scope="col">Start date</th>
           <th scope="col">End date</th>
           <th scope="col">Amount</th>
-          <th scope="col">Billed</th>
+          <th scope="col">Cost to Date</th>
           <th scope="col">Remaining</th>
         </tr>
       </thead>
@@ -70,8 +70,8 @@
             <td><%= iaa_order.start_date %></td>
             <td><%= iaa_order.end_date %></td>
             <td><%= number_to_currency(iaa_order.estimated_amount, precision: 0) %></td>
-            <td><%= number_to_currency(iaa_order.billed_amount.to_i, precision: 0) %></td>
-            <td><%= number_to_currency(iaa_order.estimated_amount - iaa_order.billed_amount.to_i, precision: 0) %></td>
+            <td><%= number_to_currency(iaa_order.cost_to_date, precision: 2) %></td>
+            <td><%= number_to_currency(iaa_order.estimated_amount - iaa_order.cost_to_date, precision: 2) %></td>
           </tr>
         <% end %>
       </tbody>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -4,6 +4,7 @@ Rails.application.routes.draw do
     resources :iaa_gtcs
     resources :iaa_orders
     resources :integrations
+    resources :integration_usages
     resources :users
     resources :account_contacts, only: %i[index show new create destroy]
     resources :integration_contacts, only: %i[index show new create destroy]

--- a/db/migrate/20201116190844_create_integration_usages.rb
+++ b/db/migrate/20201116190844_create_integration_usages.rb
@@ -1,0 +1,13 @@
+class CreateIntegrationUsages < ActiveRecord::Migration[6.0]
+  def change
+    create_table :integration_usages do |t|
+      t.references :integration, foreign_key: true
+      t.references :iaa_order, foreign_key: true
+      t.integer :auths, null: false, default: 0
+
+      t.timestamps
+
+      t.index [:integration_id, :iaa_order_id], unique: true
+    end
+  end
+end

--- a/db/migrate/20201116195021_add_billing_data_to_iaa_orders.rb
+++ b/db/migrate/20201116195021_add_billing_data_to_iaa_orders.rb
@@ -1,0 +1,12 @@
+class AddBillingDataToIAAOrders < ActiveRecord::Migration[6.0]
+  def change
+    change_table :iaa_orders do |t|
+      t.integer :platform_fee, null: false, default: 0
+      t.integer :ial2_users, null: false, default: 0
+    end
+
+    remove_column :iaa_orders, :billed_amount, :integer
+    change_column_null :iaa_orders, :estimated_amount, false
+    change_column_default :iaa_orders, :estimated_amount, from: nil, to: 0
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_11_11_022657) do
+ActiveRecord::Schema.define(version: 2020_11_16_195021) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
@@ -83,12 +83,13 @@ ActiveRecord::Schema.define(version: 2020_11_11_022657) do
     t.date "start_date"
     t.date "end_date"
     t.date "signed_date"
-    t.integer "estimated_amount"
-    t.integer "billed_amount"
+    t.integer "estimated_amount", default: 0, null: false
     t.bigint "iaa_gtc_id", null: false
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
     t.bigint "iaa_status_id"
+    t.integer "platform_fee", default: 0, null: false
+    t.integer "ial2_users", default: 0, null: false
     t.index ["iaa_gtc_id", "order_number"], name: "index_iaa_orders_on_iaa_gtc_id_and_order_number", unique: true
     t.index ["iaa_gtc_id"], name: "index_iaa_orders_on_iaa_gtc_id"
     t.index ["iaa_status_id"], name: "index_iaa_orders_on_iaa_status_id"
@@ -120,6 +121,17 @@ ActiveRecord::Schema.define(version: 2020_11_11_022657) do
     t.datetime "updated_at", precision: 6, null: false
     t.index ["name"], name: "index_integration_statuses_on_name", unique: true
     t.index ["order"], name: "index_integration_statuses_on_order", unique: true
+  end
+
+  create_table "integration_usages", force: :cascade do |t|
+    t.bigint "integration_id"
+    t.bigint "iaa_order_id"
+    t.integer "auths", default: 0, null: false
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+    t.index ["iaa_order_id"], name: "index_integration_usages_on_iaa_order_id"
+    t.index ["integration_id", "iaa_order_id"], name: "index_integration_usages_on_integration_id_and_iaa_order_id", unique: true
+    t.index ["integration_id"], name: "index_integration_usages_on_integration_id"
   end
 
   create_table "integrations", force: :cascade do |t|
@@ -168,6 +180,8 @@ ActiveRecord::Schema.define(version: 2020_11_11_022657) do
   add_foreign_key "iaa_orders", "iaa_statuses"
   add_foreign_key "integration_contacts", "integrations"
   add_foreign_key "integration_contacts", "users"
+  add_foreign_key "integration_usages", "iaa_orders"
+  add_foreign_key "integration_usages", "integrations"
   add_foreign_key "integrations", "accounts"
   add_foreign_key "integrations", "integration_statuses"
 end

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -56,6 +56,11 @@ FactoryBot.define do
     user
   end
 
+  factory :integration_usage do
+    integration
+    iaa_order
+  end
+
   factory :integration_status do
     name { Faker::Types.rb_string }
     order { Faker::Types.rb_integer }

--- a/spec/features/administrate/integration_usage_dashboard_spec.rb
+++ b/spec/features/administrate/integration_usage_dashboard_spec.rb
@@ -1,0 +1,57 @@
+require 'rails_helper'
+
+RSpec.describe 'Integration Usage dashboard', type: :feature do
+  context 'as an admin' do
+    let(:admin) { create(:user, admin: true) }
+
+    before { sign_in_with_warden(admin) }
+
+    describe 'index' do
+      it 'works' do
+        visit admin_integration_usages_path
+        expect(page).to have_content('Back to app')
+      end
+    end
+
+    describe 'create' do
+      let!(:iaa_order) { create(:iaa_order) }
+      let!(:integration) { create(:integration) }
+
+      it 'works' do
+        visit admin_integration_usages_path
+        click_on 'New Integration Usage'
+        select iaa_order.name, from: 'IAA order'
+        select integration.name, from: 'Integration'
+        click_on 'Create Integration usage'
+        expect(page).to have_content('Integration Usage was successfully created.')
+        # implictly tests the show view since that's where it redirects
+      end
+    end
+
+    describe 'update' do
+      let(:old_auths) { 0 }
+      let(:new_auths) { 1000 }
+      let(:integration_usage) { create(:integration_usage, auths: old_auths) }
+
+      it 'works' do
+        visit admin_integration_usage_path(integration_usage)
+        click_on "Edit Integration Usage ##{integration_usage.id}"
+        fill_in 'Auths', with: new_auths
+        click_on 'Update Integration usage'
+        expect(page).to have_content('Integration Usage was successfully updated.')
+      end
+    end
+
+    describe 'destroy' do
+      let!(:integration_usage) { create(:integration_usage) }
+
+      it 'works' do
+        visit admin_integration_usages_path
+        within "tr[data-url=\"#{admin_integration_usage_path(integration_usage)}\"]" do
+          click_on 'Destroy'
+        end
+        expect(page).to have_content('Integration Usage was successfully destroyed.')
+      end
+    end
+  end
+end

--- a/spec/models/iaa_order_spec.rb
+++ b/spec/models/iaa_order_spec.rb
@@ -17,13 +17,20 @@ RSpec.describe IAAOrder, type: :model do
 
     it { is_expected.to validate_presence_of(:mod_number) }
     it { is_expected.to validate_numericality_of(:mod_number).is_greater_than_or_equal_to(0) }
-    it { is_expected.to validate_numericality_of(:estimated_amount).is_greater_than_or_equal_to(0).allow_nil }
-    it { is_expected.to validate_numericality_of(:billed_amount).is_greater_than_or_equal_to(0).allow_nil }
+    it { is_expected.to validate_presence_of(:estimated_amount) }
+    it { is_expected.to validate_numericality_of(:estimated_amount).is_greater_than_or_equal_to(0) }
+    it { is_expected.to validate_presence_of(:ial2_users) }
+    it { is_expected.to validate_numericality_of(:ial2_users).is_greater_than_or_equal_to(0) }
+    it { is_expected.to validate_presence_of(:platform_fee) }
+    it { is_expected.to validate_numericality_of(:platform_fee).is_greater_than_or_equal_to(0) }
   end
 
   describe 'associations' do
+    subject { build(:iaa_order) }
+
     it { is_expected.to belong_to(:iaa_gtc) }
     it { is_expected.to belong_to(:iaa_status).optional }
+    it { is_expected.to have_many(:integration_usages).dependent(:destroy) }
   end
 
   describe '#name' do
@@ -32,6 +39,23 @@ RSpec.describe IAAOrder, type: :model do
       order = build(:iaa_order, iaa_gtc: gtc, order_number: 1, mod_number: 2)
 
       expect(order.name).to eq('FOOBAR-0001-0002')
+    end
+  end
+
+  describe '#cost_to_date' do
+    let(:iaa_order) { create(:iaa_order, platform_fee: 35_000, ial2_users: 1000) }
+
+    before do
+      allow(Figaro.env).to receive(:per_auth_cost).and_return("0.075")
+      allow(Figaro.env).to receive(:per_ial2_user_cost).and_return("5")
+      create(:integration_usage, iaa_order: iaa_order, auths: 1000)
+      create(:integration_usage, iaa_order: iaa_order, auths: 2000)
+    end
+
+    it 'returns the obligated amount based on current usage' do
+      # based on numbers above, $35k platform fee, 3000 IAL1 across all
+      # integrations, 1000 IAL2 users
+      expect(iaa_order.cost_to_date).to eq(40_225)
     end
   end
 end

--- a/spec/models/integration_spec.rb
+++ b/spec/models/integration_spec.rb
@@ -18,5 +18,6 @@ RSpec.describe Integration, type: :model do
     it { is_expected.to belong_to(:integration_status).optional }
     it { is_expected.to have_many(:integration_contacts).dependent(:destroy) }
     it { is_expected.to have_many(:contacts).through(:integration_contacts).source(:user) }
+    it { is_expected.to have_many(:integration_usages).dependent(:nullify) }
   end
 end

--- a/spec/models/integration_usage_spec.rb
+++ b/spec/models/integration_usage_spec.rb
@@ -1,0 +1,18 @@
+require 'rails_helper'
+
+RSpec.describe IntegrationUsage, type: :model do
+  describe 'validations' do
+    # subject { build(:integration_usage) }
+    subject { described_class.new }
+
+    it { is_expected.to validate_presence_of(:auths) }
+    it { is_expected.to validate_numericality_of(:auths).is_greater_than_or_equal_to(0) }
+  end
+
+  describe 'associations' do
+    subject { described_class.new }
+
+    it { is_expected.to belong_to(:iaa_order) }
+    it { is_expected.to belong_to(:integration) }
+  end
+end


### PR DESCRIPTION
* Add IntegrationUsage model to track the number of auths used by a
  given integration within the period of performance of a given order
* Add platform_fee and ial2_users attributes to IAA orders
* Add IAAOrder#amount_to_date to calculate the billable amount based on
  current usage across all associated Integrations
* Update dashboards as needed