### PR TITLE
Add partner-facing name to status lookup tables

### DIFF
--- a/app/dashboards/account_status_dashboard.rb
+++ b/app/dashboards/account_status_dashboard.rb
@@ -11,6 +11,7 @@ class AccountStatusDashboard < Administrate::BaseDashboard
     accounts: Field::HasMany,
     id: Field::Number,
     name: Field::String,
+    partner_name: Field::String,
     order: Field::Number,
     created_at: Field::DateTime,
     updated_at: Field::DateTime,
@@ -23,6 +24,7 @@ class AccountStatusDashboard < Administrate::BaseDashboard
   # Feel free to add, remove, or rearrange items.
   COLLECTION_ATTRIBUTES = %i[
   name
+  partner_name
   order
   ].freeze
 
@@ -30,6 +32,7 @@ class AccountStatusDashboard < Administrate::BaseDashboard
   # an array of attributes that will be displayed on the model's show page.
   SHOW_PAGE_ATTRIBUTES = %i[
   name
+  partner_name
   order
   accounts
   created_at
@@ -41,6 +44,7 @@ class AccountStatusDashboard < Administrate::BaseDashboard
   # on the model's form (`new` and `edit`) pages.
   FORM_ATTRIBUTES = %i[
   name
+  partner_name
   order
   ].freeze
 

--- a/app/dashboards/iaa_status_dashboard.rb
+++ b/app/dashboards/iaa_status_dashboard.rb
@@ -12,6 +12,7 @@ class IAAStatusDashboard < Administrate::BaseDashboard
     iaa_orders: Field::HasMany,
     id: Field::Number,
     name: Field::String,
+    partner_name: Field::String,
     order: Field::Number,
     created_at: Field::DateTime,
     updated_at: Field::DateTime,
@@ -24,6 +25,7 @@ class IAAStatusDashboard < Administrate::BaseDashboard
   # Feel free to add, remove, or rearrange items.
   COLLECTION_ATTRIBUTES = %i[
   name
+  partner_name
   order
   ].freeze
 
@@ -31,6 +33,7 @@ class IAAStatusDashboard < Administrate::BaseDashboard
   # an array of attributes that will be displayed on the model's show page.
   SHOW_PAGE_ATTRIBUTES = %i[
   name
+  partner_name
   order
   iaa_gtcs
   iaa_orders
@@ -43,6 +46,7 @@ class IAAStatusDashboard < Administrate::BaseDashboard
   # on the model's form (`new` and `edit`) pages.
   FORM_ATTRIBUTES = %i[
   name
+  partner_name
   order
   ].freeze
 

--- a/app/dashboards/integration_status_dashboard.rb
+++ b/app/dashboards/integration_status_dashboard.rb
@@ -11,6 +11,7 @@ class IntegrationStatusDashboard < Administrate::BaseDashboard
     integrations: Field::HasMany,
     id: Field::Number,
     name: Field::String,
+    partner_name: Field::String,
     order: Field::Number,
     created_at: Field::DateTime,
     updated_at: Field::DateTime,
@@ -23,6 +24,7 @@ class IntegrationStatusDashboard < Administrate::BaseDashboard
   # Feel free to add, remove, or rearrange items.
   COLLECTION_ATTRIBUTES = %i[
   name
+  partner_name
   order
   ].freeze
 
@@ -30,6 +32,7 @@ class IntegrationStatusDashboard < Administrate::BaseDashboard
   # an array of attributes that will be displayed on the model's show page.
   SHOW_PAGE_ATTRIBUTES = %i[
   name
+  partner_name
   order
   integrations
   created_at
@@ -41,6 +44,7 @@ class IntegrationStatusDashboard < Administrate::BaseDashboard
   # on the model's form (`new` and `edit`) pages.
   FORM_ATTRIBUTES = %i[
   name
+  partner_name
   order
   ].freeze
 

--- a/app/models/account_status.rb
+++ b/app/models/account_status.rb
@@ -6,4 +6,12 @@ class AccountStatus < ApplicationRecord
 
   default_scope { order(:order) }
   self.implicit_order_column = :order
+
+  # Override the partner_name getter to fall back to the name attribute if no
+  # specific partner name is set
+  #
+  # @return [String] the partner_name if set, otherwise the name
+  def partner_name
+    super || name
+  end
 end

--- a/app/models/iaa_status.rb
+++ b/app/models/iaa_status.rb
@@ -7,4 +7,12 @@ class IAAStatus < ApplicationRecord
 
   default_scope { order(:order) }
   self.implicit_order_column = :order
+
+  # Override the partner_name getter to fall back to the name attribute if no
+  # specific partner name is set
+  #
+  # @return [String] the partner_name if set, otherwise the name
+  def partner_name
+    super || name
+  end
 end

--- a/app/models/integration_status.rb
+++ b/app/models/integration_status.rb
@@ -6,4 +6,12 @@ class IntegrationStatus < ApplicationRecord
 
   default_scope { order(:order) }
   self.implicit_order_column = :order
+
+  # Override the partner_name getter to fall back to the name attribute if no
+  # specific partner name is set
+  #
+  # @return [String] the partner_name if set, otherwise the name
+  def partner_name
+    super || name
+  end
 end

--- a/app/views/accounts/_my_account.html.erb
+++ b/app/views/accounts/_my_account.html.erb
@@ -114,7 +114,7 @@
         <tr>
           <td><%= link_to integration.url, integration.url, target: '_blank' %></td>
           <td><%= integration.ial2 %></td>
-          <td><%= integration.integration_status.name.titleize %></td>
+          <td><%= integration.integration_status.partner_name.titleize %></td>
           <td><%= integration.go_live %></td>
           <td><%= integration.prod_deploy %></td>
         </tr>

--- a/db/migrate/20201117010222_add_partner_name_to_statuses.rb
+++ b/db/migrate/20201117010222_add_partner_name_to_statuses.rb
@@ -1,0 +1,15 @@
+class AddPartnerNameToStatuses < ActiveRecord::Migration[6.0]
+  def change
+    change_table :account_statuses do |t|
+      t.string :partner_name
+    end
+
+    change_table :iaa_statuses do |t|
+      t.string :partner_name
+    end
+
+    change_table :integration_statuses do |t|
+      t.string :partner_name
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_11_16_195021) do
+ActiveRecord::Schema.define(version: 2020_11_17_010222) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
@@ -31,6 +31,7 @@ ActiveRecord::Schema.define(version: 2020_11_16_195021) do
     t.integer "order", null: false
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
+    t.string "partner_name"
     t.index ["name"], name: "index_account_statuses_on_name", unique: true
     t.index ["order"], name: "index_account_statuses_on_order", unique: true
   end
@@ -100,6 +101,7 @@ ActiveRecord::Schema.define(version: 2020_11_16_195021) do
     t.integer "order", null: false
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
+    t.string "partner_name"
     t.index ["name"], name: "index_iaa_statuses_on_name", unique: true
     t.index ["order"], name: "index_iaa_statuses_on_order", unique: true
   end
@@ -119,6 +121,7 @@ ActiveRecord::Schema.define(version: 2020_11_16_195021) do
     t.integer "order", null: false
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
+    t.string "partner_name"
     t.index ["name"], name: "index_integration_statuses_on_name", unique: true
     t.index ["order"], name: "index_integration_statuses_on_order", unique: true
   end

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -49,22 +49,22 @@ u3 = User.create(
 }.each { |name, order| AccountStatus.find_or_create_by!(name: name, order: order) }
 
 {
-  'intake' => 0,
-  'in progress' => 100,
-  'TTS bizops' => 200,
-  'active' => 300,
-  'expired' => 400,
-  'cancelled' => 500
-}.each { |name, order| IAAStatus.find_or_create_by!(name: name, order: order) }
+  'intake' => { order: 0, partner_name: 'pending' },
+  'in progress' => { order: 100, partner_name: 'pending' },
+  'TTS bizops' => { order: 200, partner_name: 'pending' },
+  'active' => { order: 300 },
+  'expired' => { order: 400 },
+  'cancelled' => { order: 500 }
+}.each { |name, hash| IAAStatus.find_or_create_by!(name: name, order: hash[:order], partner_name: hash[:partner_name]) }
 
 {
-  'intake' => 0,
-  'in progress' => 100,
-  'config live' => 200,
-  'app live' => 300,
-  'decommissioned' => 400,
-  'cancelled' => 500
-}.each { |name, order| IntegrationStatus.find_or_create_by!(name: name, order: order) }
+  'intake' => { order: 0, partner_name: 'pending' },
+  'in progress' => { order: 100, partner_name: 'pending' },
+  'config live' => { order: 200, partner_name: 'live' },
+  'app live' => { order: 300, partner_name: 'live' },
+  'decommissioned' => { order: 400 },
+  'cancelled' => { order: 500 }
+}.each { |name, hash| IntegrationStatus.find_or_create_by!(name: name, order: hash[:order], partner_name: hash[:partner_name]) }
 
 # Import agencies
 agency_hash = YAML.load(File.read('agencies.yml'))["production"]

--- a/spec/models/account_status_spec.rb
+++ b/spec/models/account_status_spec.rb
@@ -26,4 +26,18 @@ RSpec.describe AccountStatus, type: :model do
       expect(described_class.pluck(:name)).to eq(%w[bar foo])
     end
   end
+
+  describe '#partner_name' do
+    it 'returns the attribute if set' do
+      account_status = build(:account_status, name: 'foo', partner_name: 'bar')
+
+      expect(account_status.partner_name).to eq('bar')
+    end
+
+    it 'falls back to the name if no partner_name set' do
+      account_status = build(:account_status, name: 'foo', partner_name: nil)
+
+      expect(account_status.partner_name).to eq('foo')
+    end
+  end
 end

--- a/spec/models/iaa_status_spec.rb
+++ b/spec/models/iaa_status_spec.rb
@@ -27,4 +27,18 @@ RSpec.describe IAAStatus, type: :model do
       expect(described_class.pluck(:name)).to eq(%w[bar foo])
     end
   end
+
+  describe '#partner_name' do
+    it 'returns the attribute if set' do
+      iaa_status = build(:iaa_status, name: 'foo', partner_name: 'bar')
+
+      expect(iaa_status.partner_name).to eq('bar')
+    end
+
+    it 'falls back to the name if no partner_name set' do
+      iaa_status = build(:iaa_status, name: 'foo', partner_name: nil)
+
+      expect(iaa_status.partner_name).to eq('foo')
+    end
+  end
 end

--- a/spec/models/integration_status_spec.rb
+++ b/spec/models/integration_status_spec.rb
@@ -26,4 +26,18 @@ RSpec.describe IntegrationStatus, type: :model do
       expect(described_class.pluck(:name)).to eq(%w[bar foo])
     end
   end
+
+  describe '#partner_name' do
+    it 'returns the attribute if set' do
+      integration_status = build(:integration_status, name: 'foo', partner_name: 'bar')
+
+      expect(integration_status.partner_name).to eq('bar')
+    end
+
+    it 'falls back to the name if no partner_name set' do
+      integration_status = build(:integration_status, name: 'foo', partner_name: nil)
+
+      expect(integration_status.partner_name).to eq('foo')
+    end
+  end
 end


### PR DESCRIPTION
Add an additional attribute to the three status lookup tables called
`partner_name` that is intended for use on partner-facing screens. This
allows us to have multiple internal statuses that correspond to a single
partner-facing status. Also modify the getter method for that attribute
to fall back to the `name` attribute if no `partner_name` is set.

This should be merged after #20 since the migration timestamp is after the ones in that branch.